### PR TITLE
Enable preview features for GetChangeFeedIterator

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
+++ b/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
@@ -40,7 +40,7 @@
 		<IncludeSource>false</IncludeSource>
 		<RootNamespace>Microsoft.Azure.Cosmos</RootNamespace>
 		<NoWarn>NU5125</NoWarn>
-		<PackageVersion>3.17.1.0-ca</PackageVersion>
+		<PackageVersion>3.17.1.1-ca</PackageVersion>
 		<IsPreview>true</IsPreview>
 		<Optimize Condition="'$(Configuration)'=='Release'">true</Optimize>
 	</PropertyGroup>
@@ -175,7 +175,7 @@
 	<PropertyGroup>
 		<DefineConstants Condition=" '$(SignAssembly)' == 'true' ">$(DefineConstants);SignAssembly</DefineConstants>
 		<DefineConstants Condition=" '$(DelaySign)' == 'true' ">$(DefineConstants);DelaySignKeys</DefineConstants>
-		<DefineConstants>$(DefineConstants);DOCDBCLIENT;COSMOSCLIENT;NETSTANDARD20</DefineConstants>
+		<DefineConstants>$(DefineConstants);DOCDBCLIENT;COSMOSCLIENT;NETSTANDARD20;PREVIEW</DefineConstants>
 		<LangVersion>8.0</LangVersion>
 	</PropertyGroup>
 


### PR DESCRIPTION
I intend to use the new Pull mode of the Change Feed Iterator as a replacement for Pubsub for check-ins (and more later).
This is currently a preview feature so it needs the PREVIEW compiler flag on the SDK to enable it.
