### PR TITLE
Add WhereOr to support generating logical OR

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Linq/CosmosLinqQueryExtensions.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/CosmosLinqQueryExtensions.cs
@@ -1,0 +1,33 @@
+namespace Microsoft.Azure.Cosmos.Linq;
+
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+/// <summary>
+/// Provides Cosmos Linq Query Extension methods
+/// </summary>
+public static class CosmosLinqQueryExtensions
+{
+    private static MethodInfo? _whereOrTSource2;
+
+    private static MethodInfo WhereOr_TSource_2(Type TSource) =>
+        (_whereOrTSource2 ??= new Func<IQueryable<object>, Expression<Func<object, bool>>, IQueryable<object>>(WhereOr).GetMethodInfo().GetGenericMethodDefinition())
+        .MakeGenericMethod(TSource);
+        
+    /// <summary>
+    /// Performs a logical OR of the current Expression along with the provided Predicate.
+    /// </summary>
+    /// <param name="source">The list of items</param>
+    /// <param name="predicate">The Expression to append</param>
+    /// <typeparam name="TSource">Source Query Type</typeparam>
+    /// <returns>The result of applying the predicate as an OR</returns>
+    public static IQueryable<TSource> WhereOr<TSource>(this IQueryable<TSource> source, Expression<Func<TSource,bool>> predicate) => 
+        source.Provider.CreateQuery<TSource>(
+            Expression.Call(
+            null,
+            WhereOr_TSource_2(typeof(TSource)),
+            source.Expression, Expression.Quote(predicate)));
+
+}

--- a/Microsoft.Azure.Cosmos/src/Linq/QueryUnderConstruction.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/QueryUnderConstruction.cs
@@ -495,6 +495,7 @@ namespace Microsoft.Azure.Cosmos.Linq
                     break;
 
                 case LinqMethods.Where:
+                case LinqMethods.WhereOr:
                 // Where expression parameter needs to be substitued if necessary so
                 // It is not needed in Select distinct because the Select distinct would have the necessary parameter name adjustment.
                 case LinqMethods.Any:
@@ -749,9 +750,15 @@ namespace Microsoft.Azure.Cosmos.Linq
 
             SqlScalarExpression previousFilter = first.FilterExpression;
             SqlScalarExpression currentFilter = second.FilterExpression;
-            SqlBinaryScalarExpression and = SqlBinaryScalarExpression.Create(SqlBinaryScalarOperatorKind.And, previousFilter, currentFilter);
-            SqlWhereClause result = SqlWhereClause.Create(and);
-            return result;
+            if (!second.OrClause)
+            {
+                SqlBinaryScalarExpression and = SqlBinaryScalarExpression.Create(SqlBinaryScalarOperatorKind.And, previousFilter, currentFilter);
+                SqlWhereClause resultAnd = SqlWhereClause.Create(and);
+                return resultAnd;
+            }
+            SqlBinaryScalarExpression or = SqlBinaryScalarExpression.Create(SqlBinaryScalarOperatorKind.Or, previousFilter, currentFilter);
+            SqlWhereClause resultOr = SqlWhereClause.Create(or);
+            return resultOr;
         }
 
         private static FromParameterBindings CombineInputParameters(FromParameterBindings inputQueryParams, FromParameterBindings currentQueryParams)

--- a/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
+++ b/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
@@ -41,7 +41,7 @@
 		<RootNamespace>Microsoft.Azure.Cosmos</RootNamespace>
 		<NoWarn>NU5125</NoWarn>
 		<Optimize Condition="'$(Configuration)'=='Release'">true</Optimize>
-		<PackageVersion>3.32.1005-ca</PackageVersion>
+		<PackageVersion>3.32.1006-ca</PackageVersion>
 		<LangVersion>$(LangVersion)</LangVersion>
 	</PropertyGroup>
 

--- a/Microsoft.Azure.Cosmos/src/SqlObjects/SqlWhereClause.cs
+++ b/Microsoft.Azure.Cosmos/src/SqlObjects/SqlWhereClause.cs
@@ -15,16 +15,18 @@ namespace Microsoft.Azure.Cosmos.SqlObjects
 #endif
     sealed class SqlWhereClause : SqlObject
     {
-        private SqlWhereClause(SqlScalarExpression filterExpression)
+        private SqlWhereClause(SqlScalarExpression filterExpression, bool orClause)
         {
             this.FilterExpression = filterExpression ?? throw new ArgumentNullException(nameof(filterExpression));
+            this.OrClause = orClause;
         }
 
         public SqlScalarExpression FilterExpression { get; }
+        public bool OrClause { get; }
 
-        public static SqlWhereClause Create(SqlScalarExpression filterExpression)
+        public static SqlWhereClause Create(SqlScalarExpression filterExpression, bool orClause = false)
         {
-            return new SqlWhereClause(filterExpression);
+            return new SqlWhereClause(filterExpression, orClause);
         }
 
         public override void Accept(SqlObjectVisitor visitor)


### PR DESCRIPTION
# Add WhereOr to support generating logical OR

## Description
Add the ability to use WhereOr as a LINQ extension method.
Uses a similar approach to Where but uses OR instead of AND

eg.
`DefaultPartition.QueryDocuments<CosmosEntityDocument>()
                                            .Where(x => x.Property == 4)
                                            .WhereOr(x => x.Property == 2)
                                            .WhereOr(x => x.Property == 3)
                                            .Where(x => x.Property == 5)
`

will produce
`"SELECT VALUE root FROM root WHERE ((((root.prop = 4) OR (root.prop = 2)) OR (root.prop = 3)) AND (root.prop = 5))"`

Add WhereOr clause to support generating OR expressions directly from IQueryable
- Add new CosmosLinqQueryExtensions WhereOr() in a similar way to the LINQ Where extension method
- Add OrClause property to the existing SqlWhereClause.cs that denotes it will be OR and not AND
- Add the Where or to the ExpressionToSQL.cs and include as a supported method
- Update the QueryUnderConstruction.cs to SqlBinaryScalarOperatorKind.Or when the OrClause is true, else use the old code
- Increment the NuGet package version

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

To automatically close an issue: closes #IssueNumber