### PR TITLE
Add MatchAny to Tags

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Linq/CosmosTags.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/CosmosTags.cs
@@ -2,6 +2,8 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 //------------------------------------------------------------
 
+using System.Collections;
+
 namespace Microsoft.Azure.Cosmos.Linq
 {
     using System;
@@ -36,6 +38,42 @@ namespace Microsoft.Azure.Cosmos.Linq
         Default = Basic | DocumentNotTags,
     }
 
+    public class MatchObjectList : IEnumerable<MatchObject>
+    {
+        private readonly IEnumerable<MatchObject> _matchObjects;
+
+        public MatchObjectList() => _matchObjects = Enumerable.Empty<MatchObject>();
+
+        public MatchObjectList(IEnumerable<MatchObject> matchObjects) => _matchObjects = matchObjects;
+
+        public IEnumerator<MatchObject> GetEnumerator() => _matchObjects.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => _matchObjects.GetEnumerator();
+    }
+    
+    /// <summary>
+    /// Used for TagMatchAny
+    /// </summary>
+    public class MatchObject
+    {
+        /// <summary>
+        /// The expression for the tags on the document
+        /// </summary>
+        public object DataTags { get; set; }
+        /// <summary>
+        /// The list of tags used to filter as string[]
+        /// </summary>
+        public IEnumerable<string> QueryTags { get; set; }
+        /// <summary>
+        /// The TagsQueryOptions 
+        /// </summary>
+        public TagsQueryOptions QueryOptions { get; set; }
+        /// <summary>
+        /// Optionally the name of the UdfName to use
+        /// </summary>
+        public string UdfName { get; set; }
+    }
+    
     /// <summary>
     /// Tag matching for LINQ
     /// </summary>
@@ -59,6 +97,20 @@ namespace Microsoft.Azure.Cosmos.Linq
         /// <param name="udfName">The name of the tag matching UDF when TagsQueryOptions.DocumentRequiredTags is specified</param>
         /// <returns>throws Exception</returns>
         public static bool Match(object dataTags, object queryTags, TagsQueryOptions queryOptions, string udfName = "TagsMatch") => throw new Exception("CosmosTags.Match is only for linq expressions");
+
+        /// <summary>
+        /// Tags MatchAny matching for LINQ
+        /// </summary>
+        /// <param name="filters">For each MatchObjectList performs an AND within and an OR across MatchObjectLists</param>
+        /// <returns>throws Exception</returns>
+        public static bool MatchAny(IEnumerable<MatchObjectList> filters) => throw new Exception("CosmosTags.MatchAny is only for linq expressions");
+
+        /// <summary>
+        /// Tags MatchAny matching for LINQ
+        /// </summary>
+        /// <param name="filters">For each MatchObjectList performs an AND within and an OR across MatchObjectLists</param>
+        /// <returns>throws Exception</returns>
+        public static bool MatchAny(params MatchObjectList[] filters) => throw new Exception("CosmosTags.MatchAny is only for linq expressions");
 
         /// <summary>
         /// Creates and SQL WHERE condition string from a tag match expression.

--- a/Microsoft.Azure.Cosmos/src/Linq/CosmosTags.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/CosmosTags.cs
@@ -38,17 +38,35 @@ namespace Microsoft.Azure.Cosmos.Linq
         Default = Basic | DocumentNotTags,
     }
 
+    /// <summary>
+    /// A list of MatchObjects
+    /// </summary>
     public class MatchObjectList : IEnumerable<MatchObject>
     {
-        private readonly IEnumerable<MatchObject> _matchObjects;
+        private readonly IEnumerable<MatchObject> matchObjects;
 
-        public MatchObjectList() => _matchObjects = Enumerable.Empty<MatchObject>();
+        /// <summary>
+        /// Creates a new MatchObjectList
+        /// </summary>
+        public MatchObjectList() => matchObjects = Enumerable.Empty<MatchObject>();
 
-        public MatchObjectList(IEnumerable<MatchObject> matchObjects) => _matchObjects = matchObjects;
+        /// <summary>
+        /// Creates a new MatchObjectList from an existing list
+        /// </summary>
+        /// <param name="matchObjects"></param>
+        public MatchObjectList(IEnumerable<MatchObject> matchObjects) => matchObjects = matchObjects;
 
-        public IEnumerator<MatchObject> GetEnumerator() => _matchObjects.GetEnumerator();
+        /// <summary>
+        /// Returns the enumerator from the internal list
+        /// </summary>
+        /// <returns>IEnumerator</returns>
+        public IEnumerator<MatchObject> GetEnumerator() => matchObjects.GetEnumerator();
 
-        IEnumerator IEnumerable.GetEnumerator() => _matchObjects.GetEnumerator();
+        /// <summary>
+        /// Returns the enumerator from the internal list
+        /// </summary>
+        /// <returns>IEnumerator</returns>
+        IEnumerator IEnumerable.GetEnumerator() => matchObjects.GetEnumerator();
     }
     
     /// <summary>
@@ -56,6 +74,57 @@ namespace Microsoft.Azure.Cosmos.Linq
     /// </summary>
     public class MatchObject
     {
+        /// <summary>
+        /// Creates a new MatchObject with the UdfName = TagsMatch
+        /// </summary>
+        /// <param name="dataTags"></param>
+        /// <param name="queryTags"></param>
+        /// <param name="tagsQueryOptions"></param>
+        /// <returns>new MatchObject</returns>
+        public static MatchObject Create(object dataTags, IEnumerable<string> queryTags, TagsQueryOptions tagsQueryOptions)
+            => new (dataTags, queryTags, tagsQueryOptions, "TagsMatch");
+
+        /// <summary>
+        /// Creates a new MatchObject
+        /// </summary>
+        /// <param name="dataTags"></param>
+        /// <param name="queryTags"></param>
+        /// <param name="tagsQueryOptions"></param>
+        /// <param name="udfName"></param>
+        /// <returns>new MatchObject</returns>
+        public static MatchObject Create(object dataTags, IEnumerable<string> queryTags, TagsQueryOptions tagsQueryOptions, string udfName = "TagsMatch")
+            => new (dataTags, queryTags, tagsQueryOptions, udfName);
+
+        /// <summary>
+        /// Creates a new MatchObject
+        /// </summary>
+        public MatchObject() { }
+        
+        /// <summary>
+        /// Creates a new MatchObject
+        /// </summary>
+        /// <param name="dataTags"></param>
+        /// <param name="queryTags"></param>
+        /// <param name="tagsQueryOptions"></param>
+        public MatchObject(object dataTags, IEnumerable<string> queryTags, TagsQueryOptions tagsQueryOptions): this(dataTags, queryTags, tagsQueryOptions, "TagsMatch")
+        {
+        }
+
+        /// <summary>
+        /// Creates a new MatchObject
+        /// </summary>
+        /// <param name="dataTags"></param>
+        /// <param name="queryTags"></param>
+        /// <param name="tagsQueryOptions"></param>
+        /// <param name="udfName"></param>
+        public MatchObject(object dataTags, IEnumerable<string> queryTags, TagsQueryOptions tagsQueryOptions, string udfName)
+        {
+            DataTags = dataTags;
+            QueryTags = queryTags;
+            QueryOptions = tagsQueryOptions;
+            UdfName = udfName;
+        }
+
         /// <summary>
         /// The expression for the tags on the document
         /// </summary>

--- a/Microsoft.Azure.Cosmos/src/Linq/ExpressionToSQL.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/ExpressionToSQL.cs
@@ -277,68 +277,114 @@ namespace Microsoft.Azure.Cosmos.Linq
             }
         }
 
-        private static SqlScalarExpression GetDataTagsMatchObject(MemberAssignment dataTagsBinding, TranslationContext context)
+        private static SqlScalarExpression GetDataTagsMatchObject(Expression dataTagsBinding, TranslationContext context)
         {
-            var dataTagsExpressionBinding = dataTagsBinding;
-            var dataTagsExpression = ExtractExpression<MemberExpression>(dataTagsExpressionBinding.Expression);
+            var dataTagsExpression = ExtractExpression<MemberExpression>(dataTagsBinding);
             return VisitMemberAccess(dataTagsExpression, context);
         }
-        private static IEnumerable<string> GetQueryTagsMatchObject(MemberAssignment queryTagsBinding, ParameterExpression matchParam, IEnumerable<IEnumerable<string>> matchValue)
+        private static IEnumerable<string> GetQueryTagsMatchObject(Expression queryTagsBinding, ParameterExpression matchParam, object matchValue)
         {
-            var queryLambda = Expression.Lambda(queryTagsBinding.Expression, matchParam);
-            var query = queryLambda.Compile().DynamicInvoke(matchValue);
+            var queryLambda = matchParam == null ? Expression.Lambda(queryTagsBinding) : Expression.Lambda(queryTagsBinding, matchParam);
+            var query = matchValue == null ? queryLambda.Compile().DynamicInvoke() : queryLambda.Compile().DynamicInvoke(matchValue);
             var queryTags = (IEnumerable<string>)query;
             return queryTags;
         }
-        private static IEnumerable<string> GetQueryTagsMatchObject(MemberAssignment queryTagsBinding)
+        private static TagsQueryOptions GetQueryTagsOptionsObject(Expression queryOptionsBinding)
         {
-            var queryTagsExpressionBinding = queryTagsBinding;
-            var queryTagsExpression = ExtractExpression<MethodCallExpression>(queryTagsExpressionBinding.Expression);
-            var queryLambda = Expression.Lambda(queryTagsExpression);
-            var query = queryLambda.Compile().DynamicInvoke();
-            var queryTags = (IEnumerable<string>)query;
-            return queryTags;
-        }
-        private static TagsQueryOptions GetQueryTagsOptionsObject(MemberAssignment queryOptionsBinding)
-        {
-            var queryTagsOptionsExpressionBinding = queryOptionsBinding;
-            var queryTagsOptionsExpression = ExtractExpression<ConstantExpression>(queryTagsOptionsExpressionBinding.Expression);
+            var queryTagsOptionsExpression = ExtractExpression<ConstantExpression>(queryOptionsBinding);
             var queryTagsOptions = (TagsQueryOptions)queryTagsOptionsExpression.Value;
             return queryTagsOptions;
         }
 
-        private static string GetUdfNameObject(MemberAssignment udfNameBinding)
+        private static string GetUdfNameObject(Expression udfNameBinding)
         {
-            var udfNameExpressionBinding = udfNameBinding;
-            var udfNameExpression = ExtractExpression<ConstantExpression>(udfNameExpressionBinding.Expression);
+            var udfNameExpression = ExtractExpression<ConstantExpression>(udfNameBinding);
             var udfName = udfNameExpression.Value?.ToString() ?? string.Empty;
             return udfName;
         }
 
-        private static SqlTagsMatchExpressionList GetSqlTagsMatchExpressionList(NewArrayExpression matchListObjects, TranslationContext context, ParameterExpression matchParam = null, IEnumerable<IEnumerable<string>> matchValue = null)
+        private static SqlTagsMatchExpression GetSqlTagsMatchExpression(Expression dataTagsExpression, Expression queryTagsExpression, Expression queryOptionsExpression, Expression udfNameExpression, TranslationContext context, ParameterExpression matchParam = null, object matchValue = null)
+        {
+            var dataTags = GetDataTagsMatchObject(dataTagsExpression, context);
+            var queryTags = GetQueryTagsMatchObject(queryTagsExpression, matchParam, matchValue);
+            var queryOptions = GetQueryTagsOptionsObject(queryOptionsExpression);
+
+            var udfName = "TagsMatch";
+            if (udfNameExpression != null)
+                udfName = GetUdfNameObject(udfNameExpression);
+
+            return SqlTagsMatchExpression.Create(dataTags.ToString(), queryTags, queryOptions, udfName);
+        }
+
+        private static SqlTagsMatchExpression GetSqlTagsMatchExpression(MemberInitExpression memberInitExpression, TranslationContext context, ParameterExpression matchParam = null, object matchValue = null)
+        {
+            var matchObject = ExtractExpression<MemberInitExpression>(memberInitExpression);
+            if (matchObject.Bindings.Count < 3)
+                throw new DocumentQueryException("The MatchObject must have at least 3 properties populated -> DataTags, QueryTags and QueryOptions");
+
+            Expression udfNameExpression = null;
+            if (matchObject.Bindings.Count == 4)
+                udfNameExpression = ((MemberAssignment)matchObject.Bindings[3]).Expression;
+
+            return GetSqlTagsMatchExpression(((MemberAssignment)matchObject.Bindings[0]).Expression, ((MemberAssignment)matchObject.Bindings[1]).Expression, ((MemberAssignment)matchObject.Bindings[2]).Expression, udfNameExpression, context, matchParam, matchValue);
+        }
+
+        private static SqlTagsMatchExpression GetSqlTagsMatchExpression(NewExpression newExpression, TranslationContext context, ParameterExpression matchParam = null, object matchValue = null)
+        {
+            var matchObject = ExtractExpression<NewExpression>(newExpression);
+            if (matchObject.Arguments.Count < 3)
+                throw new DocumentQueryException("The MatchObject must have at least 3 properties populated -> DataTags, QueryTags and QueryOptions");
+
+            Expression udfNameExpression = null;
+            if (matchObject.Arguments.Count == 4)
+                udfNameExpression = matchObject.Arguments[3];
+
+            return GetSqlTagsMatchExpression(matchObject.Arguments[0], matchObject.Arguments[1], matchObject.Arguments[2], udfNameExpression, context, matchParam, matchValue);
+        }
+
+        private static SqlTagsMatchExpression GetSqlTagsMatchExpression(MethodCallExpression methodCallExpression, TranslationContext context, ParameterExpression matchParam = null, object matchValue = null)
+        {
+            var matchObject = ExtractExpression<MethodCallExpression>(methodCallExpression);
+            if (matchObject.Arguments.Count < 3)
+                throw new DocumentQueryException("The MatchObject must have at least 3 properties populated -> DataTags, QueryTags and QueryOptions");
+
+            Expression udfNameExpression = null;
+            if (matchObject.Arguments.Count == 4)
+                udfNameExpression = matchObject.Arguments[3];
+
+            return GetSqlTagsMatchExpression(matchObject.Arguments[0], matchObject.Arguments[1], matchObject.Arguments[2], udfNameExpression, context, matchParam, matchValue);
+        }
+
+        private static SqlTagsMatchExpressionList GetSqlTagsMatchExpressionList(NewArrayExpression matchListObjects, TranslationContext context, ParameterExpression matchParam = null, object matchValue = null)
         {
             var sqlMatchExpressions = new List<SqlTagsMatchExpression>();
             foreach (var childExpression in matchListObjects.Expressions)
             {
-                var matchObject = ExtractExpression<MemberInitExpression>(childExpression);
-                if (matchObject.Bindings.Count < 3)
-                    throw new DocumentQueryException("The MatchAny() takes an Array of MatchObjectLists with MatchObjects");
+                //MemberInit - Handles new MatchObject { DataTags = xxxxx.... }
+                if (childExpression is MemberInitExpression memberInitExpression)
+                {
+                    var tagsMatchExpression = GetSqlTagsMatchExpression(memberInitExpression, context, matchParam, matchValue);                    
+                    sqlMatchExpressions.Add(tagsMatchExpression);
+                    continue;
+                }
 
-                var dataTags = GetDataTagsMatchObject((MemberAssignment)matchObject.Bindings[0], context);
-                var queryTags = Enumerable.Empty<string>();
-                if (matchParam != null)
-                    queryTags = GetQueryTagsMatchObject((MemberAssignment)matchObject.Bindings[1], matchParam, matchValue);
-                else
-                    queryTags = GetQueryTagsMatchObject((MemberAssignment)matchObject.Bindings[1]);
+                //New - Handles new MatchObject(xxxxx)
+                if (childExpression is NewExpression newExpression)
+                {
+                    var tagsMatchExpression = GetSqlTagsMatchExpression(newExpression, context, matchParam, matchValue);                    
+                    sqlMatchExpressions.Add(tagsMatchExpression);
+                    continue;
+                }
 
-                var queryOptions = GetQueryTagsOptionsObject((MemberAssignment)matchObject.Bindings[2]);
+                //Method - Handles MatchObject.Create(xxxxx)
+                if (childExpression is MethodCallExpression methodCallExpression)
+                {
+                    var tagsMatchExpression = GetSqlTagsMatchExpression(methodCallExpression, context, matchParam, matchValue);                    
+                    sqlMatchExpressions.Add(tagsMatchExpression);
+                    continue;
+                }
 
-                var udfName = "TagsMatch";
-                if (matchObject.Bindings.Count == 4)
-                    udfName = GetUdfNameObject((MemberAssignment)matchObject.Bindings[3]);
-
-                var tagsMatchExpression = SqlTagsMatchExpression.Create(dataTags.ToString(), queryTags, queryOptions, udfName);
-                sqlMatchExpressions.Add(tagsMatchExpression);
+                throw new NotSupportedException($"The Expression [{childExpression.Type}] is not supported. Please create a MatchObject using either new MatchObject{{}} or new MatchObject() MatchObject.Create()");
             }
 
             return SqlTagsMatchExpressionList.Create(sqlMatchExpressions);
@@ -429,37 +475,34 @@ namespace Microsoft.Azure.Cosmos.Linq
                 var arg0 = methodCallExpression.Arguments[0];
                 if (arg0 is MethodCallExpression lambdaMethodExpression)
                 {
+                    //Handles MatchAny(filters.Select(f => new MatchObjectList { xxxxx }))
                     if (lambdaMethodExpression.Method.Name == "Select")
                     {
-                        var selectManyValue =
-                            ExtractExpression<ConstantExpression>(lambdaMethodExpression.Arguments[0]);
+                        var selectValue = Expression.Lambda(lambdaMethodExpression.Arguments[0]).Compile().DynamicInvoke();
                         var lambda = ExtractExpression<LambdaExpression>(lambdaMethodExpression.Arguments[1]);
 
-                        if (selectManyValue.Value is IEnumerable<IEnumerable<IEnumerable<string>>>
-                            matchesObjectMultiple)
+                        if (selectValue is IEnumerable matchesObjectMultiple)
                         {
-                            var lambdaParam = ExtractExpression<ParameterExpression>(lambda.Parameters[0]);
                             var lambdaExpression = ExtractExpression<NewExpression>(lambda.Body);
                             var matchListObjectExpression = ExtractExpression<NewExpression>(lambdaExpression);
-                            var matchListObjects =
-                                ExtractExpression<NewArrayExpression>(matchListObjectExpression.Arguments[0]);
-
+                            var matchListObjects = ExtractExpression<NewArrayExpression>(matchListObjectExpression.Arguments[0]);
+                            
                             var results = new List<SqlTagsMatchExpressionList>();
                             foreach (var matchObjects in matchesObjectMultiple)
                             {
-                                var matchesList = GetSqlTagsMatchExpressionList(matchListObjects, context, lambdaParam,
-                                    matchObjects);
+                                var matchesList = GetSqlTagsMatchExpressionList(matchListObjects, context, lambda.Parameters[0], matchObjects);
                                 results.Add(matchesList);
                             }
 
                             return SqlTagsMatchExpressionLists.Create(results);
                         }
-
-                        throw new DocumentQueryException($"The MatchAny() Lambda Select [{selectManyValue.Value.GetType().Name}] must return an IEnumerable<IEnumerable<IEnumerable<string>>>");
+                        
+                        throw new DocumentQueryException($"The MatchAny() Lambda Select [{selectValue.GetType().Name}] must return an IEnumerable that resolves to a list of ");
                     }
-                    throw new DocumentQueryException($"The MatchAny() Lambda was not valid Select");
+                    throw new DocumentQueryException($"The MatchAny() Lambda [{lambdaMethodExpression.Method.Name}] was not valid Select");
                 }
 
+                //Handles MatchAny(new [] {new MatchObjectList[] { xxxxx } })
                 if (arg0 is NewArrayExpression argNewArray)
                 {
                     var results = new List<SqlTagsMatchExpressionList>();

--- a/Microsoft.Azure.Cosmos/src/Linq/ExpressionToSQL.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/ExpressionToSQL.cs
@@ -277,6 +277,84 @@ namespace Microsoft.Azure.Cosmos.Linq
             }
         }
 
+        private static SqlScalarExpression GetDataTagsMatchObject(MemberAssignment dataTagsBinding, TranslationContext context)
+        {
+            var dataTagsExpressionBinding = dataTagsBinding;
+            var dataTagsExpression = ExtractExpression<MemberExpression>(dataTagsExpressionBinding.Expression);
+            return VisitMemberAccess(dataTagsExpression, context);
+        }
+        private static IEnumerable<string> GetQueryTagsMatchObject(MemberAssignment queryTagsBinding, ParameterExpression matchParam, IEnumerable<IEnumerable<string>> matchValue)
+        {
+            var queryLambda = Expression.Lambda(queryTagsBinding.Expression, matchParam);
+            var query = queryLambda.Compile().DynamicInvoke(matchValue);
+            var queryTags = (IEnumerable<string>)query;
+            return queryTags;
+        }
+        private static IEnumerable<string> GetQueryTagsMatchObject(MemberAssignment queryTagsBinding)
+        {
+            var queryTagsExpressionBinding = queryTagsBinding;
+            var queryTagsExpression = ExtractExpression<MethodCallExpression>(queryTagsExpressionBinding.Expression);
+            var queryLambda = Expression.Lambda(queryTagsExpression);
+            var query = queryLambda.Compile().DynamicInvoke();
+            var queryTags = (IEnumerable<string>)query;
+            return queryTags;
+        }
+        private static TagsQueryOptions GetQueryTagsOptionsObject(MemberAssignment queryOptionsBinding)
+        {
+            var queryTagsOptionsExpressionBinding = queryOptionsBinding;
+            var queryTagsOptionsExpression = ExtractExpression<ConstantExpression>(queryTagsOptionsExpressionBinding.Expression);
+            var queryTagsOptions = (TagsQueryOptions)queryTagsOptionsExpression.Value;
+            return queryTagsOptions;
+        }
+
+        private static string GetUdfNameObject(MemberAssignment udfNameBinding)
+        {
+            var udfNameExpressionBinding = udfNameBinding;
+            var udfNameExpression = ExtractExpression<ConstantExpression>(udfNameExpressionBinding.Expression);
+            var udfName = udfNameExpression.Value?.ToString() ?? string.Empty;
+            return udfName;
+        }
+
+        private static SqlTagsMatchExpressionList GetSqlTagsMatchExpressionList(NewArrayExpression matchListObjects, TranslationContext context, ParameterExpression matchParam = null, IEnumerable<IEnumerable<string>> matchValue = null)
+        {
+            var sqlMatchExpressions = new List<SqlTagsMatchExpression>();
+            foreach (var childExpression in matchListObjects.Expressions)
+            {
+                var matchObject = ExtractExpression<MemberInitExpression>(childExpression);
+                if (matchObject.Bindings.Count < 3)
+                    throw new DocumentQueryException("The MatchAny() takes an Array of MatchObjectLists with MatchObjects");
+
+                var dataTags = GetDataTagsMatchObject((MemberAssignment)matchObject.Bindings[0], context);
+                var queryTags = Enumerable.Empty<string>();
+                if (matchParam != null)
+                    queryTags = GetQueryTagsMatchObject((MemberAssignment)matchObject.Bindings[1], matchParam, matchValue);
+                else
+                    queryTags = GetQueryTagsMatchObject((MemberAssignment)matchObject.Bindings[1]);
+
+                var queryOptions = GetQueryTagsOptionsObject((MemberAssignment)matchObject.Bindings[2]);
+
+                var udfName = "TagsMatch";
+                if (matchObject.Bindings.Count == 4)
+                    udfName = GetUdfNameObject((MemberAssignment)matchObject.Bindings[3]);
+
+                var tagsMatchExpression = SqlTagsMatchExpression.Create(dataTags.ToString(), queryTags, queryOptions, udfName);
+                sqlMatchExpressions.Add(tagsMatchExpression);
+            }
+
+            return SqlTagsMatchExpressionList.Create(sqlMatchExpressions);
+        }
+
+        private static T ExtractExpression<T>(Expression expression)
+            where T : Expression
+        {
+            if (expression is T result)
+            {
+                return result;
+            }
+
+            throw new DocumentQueryException($"The Expression was not a {typeof(T).Name}");
+        }
+
         private static SqlScalarExpression VisitMethodCallScalar(MethodCallExpression methodCallExpression, TranslationContext context)
         {
             // Check if it is a UDF method call
@@ -342,6 +420,76 @@ namespace Microsoft.Azure.Cosmos.Linq
                 if (methodCallExpression.Arguments.Count == 4)
                     udfName = (string)((ConstantExpression)methodCallExpression.Arguments[3]).Value;
                 return SqlTagsMatchExpression.Create(memberExpression.ToString(), enumerableTags ?? Enumerable.Empty<string>(), queryOptions, udfName);
+            }
+            if (methodCallExpression.Method.DeclaringType == typeof(CosmosTags) && methodCallExpression.Method.Name == "MatchAny")
+            {
+                if(methodCallExpression.Arguments.Count != 1)
+                    throw new DocumentQueryException("The MatchAny() method requires a single argument. Either supply an Array or Lambda Select");
+
+                var arg0 = methodCallExpression.Arguments[0];
+                if (arg0 is MethodCallExpression lambdaMethodExpression)
+                {
+                    if (lambdaMethodExpression.Method.Name == "Select")
+                    {
+                        var selectManyValue =
+                            ExtractExpression<ConstantExpression>(lambdaMethodExpression.Arguments[0]);
+                        var lambda = ExtractExpression<LambdaExpression>(lambdaMethodExpression.Arguments[1]);
+
+                        if (selectManyValue.Value is IEnumerable<IEnumerable<IEnumerable<string>>>
+                            matchesObjectMultiple)
+                        {
+                            var lambdaParam = ExtractExpression<ParameterExpression>(lambda.Parameters[0]);
+                            var lambdaExpression = ExtractExpression<NewExpression>(lambda.Body);
+                            var matchListObjectExpression = ExtractExpression<NewExpression>(lambdaExpression);
+                            var matchListObjects =
+                                ExtractExpression<NewArrayExpression>(matchListObjectExpression.Arguments[0]);
+
+                            var results = new List<SqlTagsMatchExpressionList>();
+                            foreach (var matchObjects in matchesObjectMultiple)
+                            {
+                                var matchesList = GetSqlTagsMatchExpressionList(matchListObjects, context, lambdaParam,
+                                    matchObjects);
+                                results.Add(matchesList);
+                            }
+
+                            return SqlTagsMatchExpressionLists.Create(results);
+                        }
+
+                        throw new DocumentQueryException($"The MatchAny() Lambda Select [{selectManyValue.Value.GetType().Name}] must return an IEnumerable<IEnumerable<IEnumerable<string>>>");
+                    }
+                    throw new DocumentQueryException($"The MatchAny() Lambda was not valid Select");
+                }
+
+                if (arg0 is NewArrayExpression argNewArray)
+                {
+                    var results = new List<SqlTagsMatchExpressionList>();
+                    foreach (var matchObjectListExpression in argNewArray.Expressions)
+                    {
+                        if (matchObjectListExpression is NewExpression matchObjectList)
+                        {
+                            var matchObjectListArgs = matchObjectList.Arguments.FirstOrDefault();
+                            if(matchObjectListArgs == null)
+                                throw new DocumentQueryException("The MatchAny() takes an Array of MatchObjectLists");
+                            
+                            if (matchObjectListArgs is NewArrayExpression matchObjectListArgArray)
+                            {
+                                 var matchesList = GetSqlTagsMatchExpressionList(matchObjectListArgArray, context);
+                                 results.Add(matchesList);
+                            }
+                            else
+                            {
+                                throw new DocumentQueryException("The MatchAny() takes an Array of MatchObjectLists");
+                            }
+                        }
+                        else
+                        {
+                            throw new DocumentQueryException("The MatchAny() takes an Array of MatchObjectLists");
+                        }
+                    }
+                    return SqlTagsMatchExpressionLists.Create(results);
+                }
+
+                throw new NotSupportedException("The MatchAny parameter was not the correct Type");
             }
             else
             {

--- a/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
+++ b/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
@@ -41,7 +41,7 @@
 		<RootNamespace>Microsoft.Azure.Cosmos</RootNamespace>
 		<NoWarn>NU5125</NoWarn>
 		<Optimize Condition="'$(Configuration)'=='Release'">true</Optimize>
-		<PackageVersion>3.32.1005-ca</PackageVersion>
+		<PackageVersion>3.32.1006-ca</PackageVersion>
 		<LangVersion>$(LangVersion)</LangVersion>
 	</PropertyGroup>
 

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CosmosQueryExecutionContextFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CosmosQueryExecutionContextFactory.cs
@@ -1067,6 +1067,16 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
                         return false;
                     }
 
+                    public override bool Visit(SqlTagsMatchExpressionList scalarExpression)
+                    {
+                        return false;
+                    }
+
+                    public override bool Visit(SqlTagsMatchExpressionLists scalarExpression)
+                    {
+                        return false;
+                    }
+
                     public override bool Visit(SqlUnaryScalarExpression sqlUnaryScalarExpression)
                     {
                         return sqlUnaryScalarExpression.Expression.Accept(this);

--- a/Microsoft.Azure.Cosmos/src/SqlObjects/SqlTagsMatchExpressionList.cs
+++ b/Microsoft.Azure.Cosmos/src/SqlObjects/SqlTagsMatchExpressionList.cs
@@ -1,0 +1,37 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+using System.Linq;
+
+namespace Microsoft.Azure.Cosmos.SqlObjects
+{
+    using System.Collections.Generic;
+    using Microsoft.Azure.Cosmos.Linq;
+    using Microsoft.Azure.Cosmos.SqlObjects.Visitors;
+
+    internal class SqlTagsMatchExpressionList : SqlScalarExpression
+    {
+        private SqlTagsMatchExpressionList(IEnumerable<SqlTagsMatchExpression> matches)
+        {
+            this.MatchesList = matches ?? new List<SqlTagsMatchExpression>();
+        }
+
+        public IEnumerable<SqlTagsMatchExpression> MatchesList { get; }
+
+        public static SqlTagsMatchExpressionList Create(IEnumerable<SqlTagsMatchExpression> matches)
+            => new SqlTagsMatchExpressionList(matches);
+
+        public override void Accept(SqlObjectVisitor visitor) => visitor.Visit(this);
+
+        public override TResult Accept<TResult>(SqlObjectVisitor<TResult> visitor) => visitor.Visit(this);
+
+        public override TResult Accept<T, TResult>(SqlObjectVisitor<T, TResult> visitor, T input) => visitor.Visit(this, input);
+
+        public override void Accept(SqlScalarExpressionVisitor visitor) => visitor.Visit(this);
+
+        public override TResult Accept<TResult>(SqlScalarExpressionVisitor<TResult> visitor) => visitor.Visit(this);
+
+        public override TResult Accept<T, TResult>(SqlScalarExpressionVisitor<T, TResult> visitor, T input) => visitor.Visit(this, input);
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/SqlObjects/SqlTagsMatchExpressionLists.cs
+++ b/Microsoft.Azure.Cosmos/src/SqlObjects/SqlTagsMatchExpressionLists.cs
@@ -1,0 +1,37 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+using System.Linq;
+
+namespace Microsoft.Azure.Cosmos.SqlObjects
+{
+    using System.Collections.Generic;
+    using Microsoft.Azure.Cosmos.Linq;
+    using Microsoft.Azure.Cosmos.SqlObjects.Visitors;
+
+    internal class SqlTagsMatchExpressionLists : SqlScalarExpression
+    {
+        private SqlTagsMatchExpressionLists(IEnumerable<SqlTagsMatchExpressionList> matches)
+        {
+            this.MatchesList = matches ?? new List<SqlTagsMatchExpressionList>();
+        }
+
+        public IEnumerable<SqlTagsMatchExpressionList> MatchesList { get; }
+
+        public static SqlTagsMatchExpressionLists Create(IEnumerable<SqlTagsMatchExpressionList> matches)
+            => new SqlTagsMatchExpressionLists(matches);
+
+        public override void Accept(SqlObjectVisitor visitor) => visitor.Visit(this);
+
+        public override TResult Accept<TResult>(SqlObjectVisitor<TResult> visitor) => visitor.Visit(this);
+
+        public override TResult Accept<T, TResult>(SqlObjectVisitor<T, TResult> visitor, T input) => visitor.Visit(this, input);
+
+        public override void Accept(SqlScalarExpressionVisitor visitor) => visitor.Visit(this);
+
+        public override TResult Accept<TResult>(SqlScalarExpressionVisitor<TResult> visitor) => visitor.Visit(this);
+
+        public override TResult Accept<T, TResult>(SqlScalarExpressionVisitor<T, TResult> visitor, T input) => visitor.Visit(this, input);
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/SqlObjects/Visitors/SqlObjectEqualityVisitor.cs
+++ b/Microsoft.Azure.Cosmos/src/SqlObjects/Visitors/SqlObjectEqualityVisitor.cs
@@ -906,6 +906,52 @@ namespace Microsoft.Azure.Cosmos.SqlObjects.Visitors
             return true;
         }
 
+        public override bool Visit(SqlTagsMatchExpressionList first, SqlObject secondAsObject)
+        {
+            if (!(secondAsObject is SqlTagsMatchExpressionList second))
+            {
+                return false;
+            }
+
+            if (!Equals(first.MatchesList.Count(), second.MatchesList.Count()))
+            {
+                return false;
+            }
+
+            foreach (var firstMatch in first.MatchesList)
+            {
+                foreach (var secondMatch in second.MatchesList)
+                {
+                    if (!firstMatch.Equals(secondMatch))
+                        return false;
+                }                    
+            }
+
+            return true;
+        }
+
+        public override bool Visit(SqlTagsMatchExpressionLists first, SqlObject secondAsObject)
+        {
+            if (!(secondAsObject is SqlTagsMatchExpressionLists second))
+            {
+                return false;
+            }
+
+            if (!Equals(first.MatchesList.Count(), second.MatchesList.Count()))
+            {
+                return false;
+            }
+
+            foreach (var firstMatch in first.MatchesList)
+            {
+                var secondMatch = second.MatchesList.Any(x => Equals(firstMatch, x));
+                if (!secondMatch)
+                    return false;
+            }
+
+            return true;
+        }
+
         public override bool Visit(SqlTopSpec first, SqlObject secondAsObject)
         {
             if (!(secondAsObject is SqlTopSpec second))

--- a/Microsoft.Azure.Cosmos/src/SqlObjects/Visitors/SqlObjectHasher.cs
+++ b/Microsoft.Azure.Cosmos/src/SqlObjects/Visitors/SqlObjectHasher.cs
@@ -67,6 +67,7 @@ namespace Microsoft.Azure.Cosmos.SqlObjects.Visitors
         private const int SqlSubqueryCollectionHashCode = 1175697100;
         private const int SqlSubqueryScalarExpressionHashCode = -1327458193;
         private const int SqlTagsMatchExpressionHashCode = 957110162;
+        private const int SqlTagsMatchExpressionListHashCode = 957110163;
         private const int SqlTopSpecHashCode = -791376698;
         private const int SqlUnaryScalarExpressionHashCode = 723832597;
         private const int SqlUndefinedLiteralHashCode = 1290712518;
@@ -603,6 +604,22 @@ namespace Microsoft.Azure.Cosmos.SqlObjects.Visitors
             foreach (string tag in sqlTagsMatchExpression.Tags)
                 hashCode = CombineHashes(hashCode, tag.GetHashCode());
             hashCode = CombineHashes(hashCode, sqlTagsMatchExpression.QueryOptions.GetHashCode());
+            return hashCode;
+        }
+
+        public override int Visit(SqlTagsMatchExpressionList sqlTagsMatchExpressionList)
+        {
+            int hashCode = SqlTagsMatchExpressionListHashCode;
+            foreach (var match in sqlTagsMatchExpressionList.MatchesList)
+                hashCode = CombineHashes(hashCode, match.GetHashCode());
+            return hashCode;
+        }
+
+        public override int Visit(SqlTagsMatchExpressionLists sqlTagsMatchExpressionLists)
+        {
+            int hashCode = SqlTagsMatchExpressionListHashCode;
+            foreach (var match in sqlTagsMatchExpressionLists.MatchesList)
+                hashCode = CombineHashes(hashCode, match.GetHashCode());
             return hashCode;
         }
 

--- a/Microsoft.Azure.Cosmos/src/SqlObjects/Visitors/SqlObjectObfuscator.cs
+++ b/Microsoft.Azure.Cosmos/src/SqlObjects/Visitors/SqlObjectObfuscator.cs
@@ -398,6 +398,18 @@ namespace Microsoft.Azure.Cosmos.SqlObjects.Visitors
             return sqlObject;
         }
 
+        public override SqlObject Visit(SqlTagsMatchExpressionList sqlObject)
+        {
+            // No idea what this obfuscator does
+            return sqlObject;
+        }
+
+        public override SqlObject Visit(SqlTagsMatchExpressionLists sqlObject)
+        {
+            // No idea what this obfuscator does
+            return sqlObject;
+        }
+
         public override SqlObject Visit(SqlTopSpec sqlTopSpec)
         {
             return SqlTopSpec.Create(SqlNumberLiteral.Create(0));

--- a/Microsoft.Azure.Cosmos/src/SqlObjects/Visitors/SqlObjectTextSerializer.cs
+++ b/Microsoft.Azure.Cosmos/src/SqlObjects/Visitors/SqlObjectTextSerializer.cs
@@ -612,6 +612,48 @@ namespace Microsoft.Azure.Cosmos.SqlObjects.Visitors
             this.writer.Write(CosmosTags.Condition(tagsProp, tags, queryOptions, udfName));
         }
 
+        public override void Visit(SqlTagsMatchExpressionList sqlObject)
+        {
+            var matchesList = sqlObject.MatchesList;
+            if (matchesList == null || !matchesList.Any())
+            {
+                this.writer.Write("true");
+                return;
+            }
+            this.writer.Write("(");
+            for (int i = 0; i < matchesList.Count(); i++)
+            {
+                if (i > 0) this.writer.Write(" AND ");
+
+                var match = matchesList.ElementAt(i);
+                this.writer.Write("(");
+                Visit(match);
+                this.writer.Write(")");
+            }
+            this.writer.Write(")");
+        }
+
+        public override void Visit(SqlTagsMatchExpressionLists sqlObject)
+        {
+            var matchesList = sqlObject.MatchesList;
+            if (matchesList == null || !matchesList.Any())
+            {
+                this.writer.Write("true");
+                return;
+            }
+            this.writer.Write("(");
+            for (int i = 0; i < matchesList.Count(); i++)
+            {
+                if (i > 0) this.writer.Write(" OR ");
+                    
+                var matchList = matchesList.ElementAt(i);
+                this.writer.Write("(");
+                Visit(matchList);                
+                this.writer.Write(")");
+            }
+            this.writer.Write(")");
+        }
+
         public override void Visit(SqlTopSpec sqlTopSpec)
         {
             this.writer.Write("TOP ");

--- a/Microsoft.Azure.Cosmos/src/SqlObjects/Visitors/SqlObjectVisitor.cs
+++ b/Microsoft.Azure.Cosmos/src/SqlObjects/Visitors/SqlObjectVisitor.cs
@@ -61,6 +61,8 @@ namespace Microsoft.Azure.Cosmos.SqlObjects.Visitors
         public abstract void Visit(SqlSubqueryCollection sqlObject);
         public abstract void Visit(SqlSubqueryScalarExpression sqlObject);
         public abstract void Visit(SqlTagsMatchExpression sqlObject);
+        public abstract void Visit(SqlTagsMatchExpressionList sqlObject);
+        public abstract void Visit(SqlTagsMatchExpressionLists sqlObject);
         public abstract void Visit(SqlTopSpec sqlObject);
         public abstract void Visit(SqlUnaryScalarExpression sqlObject);
         public abstract void Visit(SqlUndefinedLiteral sqlObject);

--- a/Microsoft.Azure.Cosmos/src/SqlObjects/Visitors/SqlObjectVisitor{TArg,TOutput}.cs
+++ b/Microsoft.Azure.Cosmos/src/SqlObjects/Visitors/SqlObjectVisitor{TArg,TOutput}.cs
@@ -61,6 +61,8 @@ namespace Microsoft.Azure.Cosmos.SqlObjects.Visitors
         public abstract TOutput Visit(SqlSubqueryCollection sqlObject, TArg input);
         public abstract TOutput Visit(SqlSubqueryScalarExpression sqlObject, TArg input);
         public abstract TOutput Visit(SqlTagsMatchExpression sqlObject, TArg input);
+        public abstract TOutput Visit(SqlTagsMatchExpressionList sqlObject, TArg input);
+        public abstract TOutput Visit(SqlTagsMatchExpressionLists sqlObject, TArg input);
         public abstract TOutput Visit(SqlTopSpec sqlObject, TArg input);
         public abstract TOutput Visit(SqlUnaryScalarExpression sqlObject, TArg input);
         public abstract TOutput Visit(SqlUndefinedLiteral sqlObject, TArg input);

--- a/Microsoft.Azure.Cosmos/src/SqlObjects/Visitors/SqlObjectVisitor{TResult}.cs
+++ b/Microsoft.Azure.Cosmos/src/SqlObjects/Visitors/SqlObjectVisitor{TResult}.cs
@@ -61,6 +61,8 @@ namespace Microsoft.Azure.Cosmos.SqlObjects.Visitors
         public abstract TResult Visit(SqlSubqueryCollection sqlObject);
         public abstract TResult Visit(SqlSubqueryScalarExpression sqlObject);
         public abstract TResult Visit(SqlTagsMatchExpression sqlObject);
+        public abstract TResult Visit(SqlTagsMatchExpressionList sqlObject);
+        public abstract TResult Visit(SqlTagsMatchExpressionLists sqlObject);
         public abstract TResult Visit(SqlTopSpec sqlObject);
         public abstract TResult Visit(SqlUnaryScalarExpression sqlObject);
         public abstract TResult Visit(SqlUndefinedLiteral sqlObject);

--- a/Microsoft.Azure.Cosmos/src/SqlObjects/Visitors/SqlScalarExpressionVisitor.cs
+++ b/Microsoft.Azure.Cosmos/src/SqlObjects/Visitors/SqlScalarExpressionVisitor.cs
@@ -30,6 +30,8 @@ namespace Microsoft.Azure.Cosmos.SqlObjects.Visitors
         public abstract void Visit(SqlPropertyRefScalarExpression scalarExpression);
         public abstract void Visit(SqlSubqueryScalarExpression scalarExpression);
         public abstract void Visit(SqlTagsMatchExpression scalarExpression);
+        public abstract void Visit(SqlTagsMatchExpressionList scalarExpression);
+        public abstract void Visit(SqlTagsMatchExpressionLists scalarExpression);
         public abstract void Visit(SqlUnaryScalarExpression scalarExpression);
     }
 }

--- a/Microsoft.Azure.Cosmos/src/SqlObjects/Visitors/SqlScalarExpressionVisitor{TArg,TOutput}.cs
+++ b/Microsoft.Azure.Cosmos/src/SqlObjects/Visitors/SqlScalarExpressionVisitor{TArg,TOutput}.cs
@@ -31,6 +31,8 @@ namespace Microsoft.Azure.Cosmos.SqlObjects.Visitors
         public abstract TOutput Visit(SqlPropertyRefScalarExpression scalarExpression, TArg input);
         public abstract TOutput Visit(SqlSubqueryScalarExpression scalarExpression, TArg input);
         public abstract TOutput Visit(SqlTagsMatchExpression sqlObject, TArg input);
+        public abstract TOutput Visit(SqlTagsMatchExpressionList sqlObject, TArg input);
+        public abstract TOutput Visit(SqlTagsMatchExpressionLists sqlObject, TArg input);
         public abstract TOutput Visit(SqlUnaryScalarExpression scalarExpression, TArg input);
     }
 }

--- a/Microsoft.Azure.Cosmos/src/SqlObjects/Visitors/SqlScalarExpressionVisitor{TResult}.cs
+++ b/Microsoft.Azure.Cosmos/src/SqlObjects/Visitors/SqlScalarExpressionVisitor{TResult}.cs
@@ -31,6 +31,8 @@ namespace Microsoft.Azure.Cosmos.SqlObjects.Visitors
         public abstract TResult Visit(SqlPropertyRefScalarExpression scalarExpression);
         public abstract TResult Visit(SqlSubqueryScalarExpression scalarExpression);
         public abstract TResult Visit(SqlTagsMatchExpression scalarExpression);
+        public abstract TResult Visit(SqlTagsMatchExpressionList scalarExpression);
+        public abstract TResult Visit(SqlTagsMatchExpressionLists scalarExpression);
         public abstract TResult Visit(SqlUnaryScalarExpression scalarExpression);
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqTranslationBaselineTests.TestSpecialMethods.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqTranslationBaselineTests.TestSpecialMethods.xml
@@ -54,4 +54,69 @@ SELECT VALUE root["EnumerableField"][0]
 FROM root]]></SqlQuery>
     </Output>
   </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[TagsMatch]]></Description>
+      <Expression><![CDATA[query.Where(doc => Match(doc.TagsField, new [] {"ns:name=1"}, Default))]]></Expression>
+    </Input>
+    <Output>
+      <SqlQuery><![CDATA[
+SELECT VALUE root 
+FROM root 
+WHERE ((NOT(IS_DEFINED(root["TagsField"]["tags"]["!ns:name"])) OR NOT(ARRAY_CONTAINS(root["TagsField"]["tag"], "!ns:name=")) AND NOT(ARRAY_CONTAINS(root["TagsField"]["tag"], "!ns:name=1"))) AND (NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:name"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:name=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:name=1")))]]></SqlQuery>
+      <ErrorMessage><![CDATA[CosmosTags.Match is only for linq expressions]]></ErrorMessage>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[TagsMatchAnySingleArray]]></Description>
+      <Expression><![CDATA[query.Where(doc => MatchAny(new [] {new MatchObjectList(new [] {new MatchObject() {DataTags = doc.TagsField, QueryTags = DisplayClass.matchFilter1.get_Item(0), QueryOptions = Basic, UdfName = "UdfName1"}, new MatchObject() {DataTags = doc.TagsField1, QueryTags = DisplayClass.matchFilter1.get_Item(1), QueryOptions = Basic}})}))]]></Expression>
+    </Input>
+    <Output>
+      <SqlQuery><![CDATA[
+SELECT VALUE root 
+FROM root 
+WHERE ((((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue1") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue2")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value1") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value2")))))))]]></SqlQuery>
+      <ErrorMessage><![CDATA[CosmosTags.Match is only for linq expressions]]></ErrorMessage>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[TagsMatchAnyMultipleArray]]></Description>
+      <Expression><![CDATA[query.Where(doc => MatchAny(new [] {new MatchObjectList(new [] {new MatchObject() {DataTags = doc.TagsField, QueryTags = DisplayClass.matchFilter1.get_Item(0), QueryOptions = Basic, UdfName = "UdfName1"}, new MatchObject() {DataTags = doc.TagsField1, QueryTags = DisplayClass.matchFilter1.get_Item(1), QueryOptions = Basic}}), new MatchObjectList(new [] {new MatchObject() {DataTags = doc.TagsField, QueryTags = DisplayClass.matchFilter2.get_Item(0), QueryOptions = Basic, UdfName = "UdfName1"}, new MatchObject() {DataTags = doc.TagsField1, QueryTags = DisplayClass.matchFilter2.get_Item(1), QueryOptions = Basic}})}))]]></Expression>
+    </Input>
+    <Output>
+      <SqlQuery><![CDATA[
+SELECT VALUE root 
+FROM root 
+WHERE ((((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue1") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue2")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value1") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value2")))))) OR (((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue3") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue4")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value3") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value4")))))))]]></SqlQuery>
+      <ErrorMessage><![CDATA[CosmosTags.Match is only for linq expressions]]></ErrorMessage>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[TagsMatchAnySingleLinq]]></Description>
+      <Expression><![CDATA[query.Where(doc => MatchAny(DisplayClass.matchFilters.Select(f => new MatchObjectList(new [] {new MatchObject() {DataTags = doc.TagsField, QueryTags = f.get_Item(0), QueryOptions = Basic, UdfName = "UdfName1"}, new MatchObject() {DataTags = doc.TagsField1, QueryTags = f.get_Item(1), QueryOptions = Basic}}))))]]></Expression>
+    </Input>
+    <Output>
+      <SqlQuery><![CDATA[
+SELECT VALUE root 
+FROM root 
+WHERE ((((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue1") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue2")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value1") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value2")))))) OR (((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue3") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue4")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value3") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value4")))))))]]></SqlQuery>
+      <ErrorMessage><![CDATA[CosmosTags.Match is only for linq expressions]]></ErrorMessage>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[TagsMatchAnySingleLinqQuery]]></Description>
+      <Expression><![CDATA[query.Where(doc => MatchAny(DisplayClass.queryFilters.Select(f => new MatchObjectList(new [] {new MatchObject() {DataTags = doc.TagsField, QueryTags = f[0], QueryOptions = Basic, UdfName = "UdfName1"}, new MatchObject() {DataTags = doc.TagsField1, QueryTags = f[1], QueryOptions = Basic}}))))]]></Expression>
+    </Input>
+    <Output>
+      <SqlQuery><![CDATA[
+SELECT VALUE root 
+FROM root 
+WHERE ((((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue1") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue2")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value1") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value2")))))) OR (((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue3") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue4")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value3") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value4")))))))]]></SqlQuery>
+      <ErrorMessage><![CDATA[CosmosTags.Match is only for linq expressions]]></ErrorMessage>
+    </Output>
+  </Result>
 </Results>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqTranslationBaselineTests.TestSpecialMethods.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqTranslationBaselineTests.TestSpecialMethods.xml
@@ -77,7 +77,7 @@ WHERE ((NOT(IS_DEFINED(root["TagsField"]["tags"]["!ns:name"])) OR NOT(ARRAY_CONT
 SELECT VALUE root 
 FROM root 
 WHERE ((((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue1") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue2")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value1") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value2")))))))]]></SqlQuery>
-      <ErrorMessage><![CDATA[CosmosTags.Match is only for linq expressions]]></ErrorMessage>
+      <ErrorMessage><![CDATA[CosmosTags.MatchAny is only for linq expressions]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -90,7 +90,7 @@ WHERE ((((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CO
 SELECT VALUE root 
 FROM root 
 WHERE ((((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue1") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue2")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value1") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value2")))))) OR (((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue3") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue4")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value3") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value4")))))))]]></SqlQuery>
-      <ErrorMessage><![CDATA[CosmosTags.Match is only for linq expressions]]></ErrorMessage>
+      <ErrorMessage><![CDATA[CosmosTags.MatchAny is only for linq expressions]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -103,7 +103,7 @@ WHERE ((((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CO
 SELECT VALUE root 
 FROM root 
 WHERE ((((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue1") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue2")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value1") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value2")))))) OR (((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue3") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue4")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value3") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value4")))))))]]></SqlQuery>
-      <ErrorMessage><![CDATA[CosmosTags.Match is only for linq expressions]]></ErrorMessage>
+      <ErrorMessage><![CDATA[CosmosTags.MatchAny is only for linq expressions]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -116,7 +116,98 @@ WHERE ((((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CO
 SELECT VALUE root 
 FROM root 
 WHERE ((((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue1") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue2")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value1") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value2")))))) OR (((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue3") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue4")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value3") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value4")))))))]]></SqlQuery>
-      <ErrorMessage><![CDATA[CosmosTags.Match is only for linq expressions]]></ErrorMessage>
+      <ErrorMessage><![CDATA[CosmosTags.MatchAny is only for linq expressions]]></ErrorMessage>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[TagsMatchAnySingleLinqQuery]]></Description>
+      <Expression><![CDATA[query.Where(doc => MatchAny(DisplayClass.filters.Select(f => new MatchObjectList(new [] {new MatchObject() {DataTags = doc.TagsField, QueryTags = f.Item1, QueryOptions = Basic, UdfName = "UdfName1"}, new MatchObject() {DataTags = doc.TagsField1, QueryTags = f.Item2, QueryOptions = Basic}}))))]]></Expression>
+    </Input>
+    <Output>
+      <SqlQuery><![CDATA[
+SELECT VALUE root 
+FROM root 
+WHERE ((((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue1") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue2")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value1") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value2")))))) OR (((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue3") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue4")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value3") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value4")))))))]]></SqlQuery>
+      <ErrorMessage><![CDATA[CosmosTags.MatchAny is only for linq expressions]]></ErrorMessage>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[TagsMatchAnySingleArrayConstructor]]></Description>
+      <Expression><![CDATA[query.Where(doc => MatchAny(new [] {new MatchObjectList(new [] {new MatchObject(doc.TagsField, DisplayClass.matchFilter1.get_Item(0), Basic, "UdfName1"), Create(doc.TagsField1, DisplayClass.matchFilter1.get_Item(1), Basic)})}))]]></Expression>
+    </Input>
+    <Output>
+      <SqlQuery><![CDATA[
+SELECT VALUE root 
+FROM root 
+WHERE ((((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue1") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue2")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value1") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value2")))))))]]></SqlQuery>
+      <ErrorMessage><![CDATA[CosmosTags.MatchAny is only for linq expressions]]></ErrorMessage>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[TagsMatchAnyMultipleArrayConstructor]]></Description>
+      <Expression><![CDATA[query.Where(doc => MatchAny(new [] {new MatchObjectList(new [] {new MatchObject(doc.TagsField, DisplayClass.matchFilter1.get_Item(0), Basic, "UdfName1"), Create(doc.TagsField1, DisplayClass.matchFilter1.get_Item(1), Basic)}), new MatchObjectList(new [] {new MatchObject(doc.TagsField, DisplayClass.matchFilter2.get_Item(0), Basic, "UdfName1"), Create(doc.TagsField1, DisplayClass.matchFilter2.get_Item(1), Basic)})}))]]></Expression>
+    </Input>
+    <Output>
+      <SqlQuery><![CDATA[
+SELECT VALUE root 
+FROM root 
+WHERE ((((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue1") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue2")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value1") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value2")))))) OR (((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue3") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue4")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value3") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value4")))))))]]></SqlQuery>
+      <ErrorMessage><![CDATA[CosmosTags.MatchAny is only for linq expressions]]></ErrorMessage>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[TagsMatchAnySingleLinqConstructor]]></Description>
+      <Expression><![CDATA[query.Where(doc => MatchAny(DisplayClass.matchFilters.Select(f => new MatchObjectList(new [] {new MatchObject(doc.TagsField, f.get_Item(0), Basic, "UdfName1"), Create(doc.TagsField1, f.get_Item(1), Basic)}))))]]></Expression>
+    </Input>
+    <Output>
+      <SqlQuery><![CDATA[
+SELECT VALUE root 
+FROM root 
+WHERE ((((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue1") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue2")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value1") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value2")))))) OR (((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue3") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue4")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value3") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value4")))))))]]></SqlQuery>
+      <ErrorMessage><![CDATA[CosmosTags.MatchAny is only for linq expressions]]></ErrorMessage>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[TagsMatchAnySingleLinqQueryConstructor]]></Description>
+      <Expression><![CDATA[query.Where(doc => MatchAny(DisplayClass.queryFilters.Select(f => new MatchObjectList(new [] {new MatchObject(doc.TagsField, f[0], Basic, "UdfName1"), Create(doc.TagsField1, f[1], Basic)}))))]]></Expression>
+    </Input>
+    <Output>
+      <SqlQuery><![CDATA[
+SELECT VALUE root 
+FROM root 
+WHERE ((((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue1") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue2")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value1") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value2")))))) OR (((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue3") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue4")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value3") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value4")))))))]]></SqlQuery>
+      <ErrorMessage><![CDATA[CosmosTags.MatchAny is only for linq expressions]]></ErrorMessage>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[TagsMatchAnySingleLinqQuerySelectConstructor]]></Description>
+      <Expression><![CDATA[query.Where(doc => MatchAny(DisplayClass.queryFilters.Select(f => new MatchObjectList(new [] {new MatchObject(doc.TagsField, f[0], Basic, "UdfName1"), Create(doc.TagsField1, f[1], Basic)}))))]]></Expression>
+    </Input>
+    <Output>
+      <SqlQuery><![CDATA[
+SELECT VALUE root 
+FROM root 
+WHERE ((((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue1") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue2")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value1") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value2")))))) OR (((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue3") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue4")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value3") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value4")))))))]]></SqlQuery>
+      <ErrorMessage><![CDATA[CosmosTags.MatchAny is only for linq expressions]]></ErrorMessage>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[TagsMatchAnySingleLinqQuerySelectTupleConstructor]]></Description>
+      <Expression><![CDATA[query.Where(doc => MatchAny(DisplayClass.filters.Select(f => new MatchObjectList(new [] {new MatchObject(doc.TagsField, f.Item1, Basic, "UdfName1"), Create(doc.TagsField1, f.Item2, Basic)}))))]]></Expression>
+    </Input>
+    <Output>
+      <SqlQuery><![CDATA[
+SELECT VALUE root 
+FROM root 
+WHERE ((((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue1") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue2")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value1") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value2")))))) OR (((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue3") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue4")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value3") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value4")))))))]]></SqlQuery>
+      <ErrorMessage><![CDATA[CosmosTags.MatchAny is only for linq expressions]]></ErrorMessage>
     </Output>
   </Result>
 </Results>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/LinqTranslationBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/LinqTranslationBaselineTests.cs
@@ -982,8 +982,91 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests.LinqProviderTests
                                 new MatchObject{DataTags = doc.TagsField1, QueryTags = f[1], QueryOptions = TagsQueryOptions.Basic }
                             }
                         )
+                    )))),
+                // TagsMatchAnyMultipleLinqSelect
+                new LinqTestInput("TagsMatchAnySingleLinqQuery", b => getQuery(b).Where(doc => CosmosTags.MatchAny(
+                    filters.Select(f =>
+                        new MatchObjectList
+                        (
+                            new []
+                            {
+                                new MatchObject{DataTags = doc.TagsField, QueryTags = f.matchFilters1, QueryOptions = TagsQueryOptions.Basic, UdfName = "UdfName1"},
+                                new MatchObject{DataTags = doc.TagsField1, QueryTags = f.matchFilters2, QueryOptions = TagsQueryOptions.Basic }
+                            }
+                        )
+                    )))),
+                // TagsMatchAnySingleArrayConstructor
+                new LinqTestInput("TagsMatchAnySingleArrayConstructor", b => getQuery(b).Where(doc => CosmosTags.MatchAny(
+                    new MatchObjectList(
+                        new []
+                            {
+                                new MatchObject(doc.TagsField, matchFilter1[0], TagsQueryOptions.Basic, "UdfName1"),
+                                MatchObject.Create(doc.TagsField1, matchFilter1[1], TagsQueryOptions.Basic)
+                            }
+                        )))),
+                // TagsMatchAnyMultipleArrayConstructor
+                new LinqTestInput("TagsMatchAnyMultipleArrayConstructor", b => getQuery(b).Where(doc => CosmosTags.MatchAny(
+                    new MatchObjectList(
+                        new []
+                        {
+                            new MatchObject(doc.TagsField, matchFilter1[0], TagsQueryOptions.Basic, "UdfName1"),
+                            MatchObject.Create(doc.TagsField1, matchFilter1[1], TagsQueryOptions.Basic)
+                        }),
+                        new MatchObjectList(
+                        new []
+                        {
+                            new MatchObject(doc.TagsField, matchFilter2[0], TagsQueryOptions.Basic, "UdfName1"),
+                            MatchObject.Create(doc.TagsField1, matchFilter2[1], TagsQueryOptions.Basic)
+                        })
+                    ))),
+                // TagsMatchAnySingleLinqConstructor
+                new LinqTestInput("TagsMatchAnySingleLinqConstructor", b => getQuery(b).Where(doc => CosmosTags.MatchAny(
+                    matchFilters.Select(f =>
+                        new MatchObjectList
+                        (
+                            new []
+                            {
+                                new MatchObject(doc.TagsField, f[0], TagsQueryOptions.Basic, "UdfName1"),
+                                MatchObject.Create(doc.TagsField1, f[1], TagsQueryOptions.Basic)
+                            }
+                        )
+                    )))),
+                // TagsMatchAnyMultipleLinqConstructor
+                new LinqTestInput("TagsMatchAnySingleLinqQueryConstructor", b => getQuery(b).Where(doc => CosmosTags.MatchAny(
+                    queryFilters.Select(f =>
+                        new MatchObjectList
+                        (
+                            new []
+                            {
+                                new MatchObject(doc.TagsField, f[0], TagsQueryOptions.Basic, "UdfName1"),
+                                MatchObject.Create(doc.TagsField1, f[1], TagsQueryOptions.Basic)
+                            }
+                        )
+                   )))),
+                // TagsMatchAnyMultipleLinqSelectConstructor
+                new LinqTestInput("TagsMatchAnySingleLinqQuerySelectConstructor", b => getQuery(b).Where(doc => CosmosTags.MatchAny(
+                    queryFilters.Select(f =>
+                        new MatchObjectList
+                        (
+                            new []
+                            {
+                                new MatchObject(doc.TagsField, f[0], TagsQueryOptions.Basic, "UdfName1"),
+                                MatchObject.Create(doc.TagsField1, f[1], TagsQueryOptions.Basic)
+                            }
+                        )
+                    )))),
+                // TagsMatchAnyMultipleLinqSelectConstructor
+                new LinqTestInput("TagsMatchAnySingleLinqQuerySelectTupleConstructor", b => getQuery(b).Where(doc => CosmosTags.MatchAny(
+                    filters.Select(f =>
+                        new MatchObjectList
+                        (
+                            new []
+                            {
+                                new MatchObject(doc.TagsField, f.matchFilters1, TagsQueryOptions.Basic, "UdfName1"),
+                                MatchObject.Create(doc.TagsField1, f.matchFilters2, TagsQueryOptions.Basic)
+                            }
+                        )
                     ))))
-
             };
             this.ExecuteTestSuite(inputs);
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/LinqTranslationBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/LinqTranslationBaselineTests.cs
@@ -153,6 +153,7 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests.LinqProviderTests
             public string Pk;
 
             public string[] TagsField;
+            public string[] TagsField1;
         }
 
         class DateJsonConverter : IsoDateTimeConverter
@@ -889,10 +890,37 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests.LinqProviderTests
                 obj.Id = Guid.NewGuid().ToString();
                 obj.Pk = "Test";
                 obj.TagsField = new string[0];
+                obj.TagsField1 = new string[0];
                 return obj;
             };
             Func<bool, IQueryable<DataObject>> getQuery = LinqTestsCommon.GenerateTestCosmosData(createDataObj, Records, testContainer);
 
+            var matchFilters = new List<List<IEnumerable<string>>>();
+            matchFilters.Add(new List<IEnumerable<string>>());
+            matchFilters[0].Add(new [] { "ns:tagname=tagvalue1", "ns:tagname=tagvalue2" } );
+            matchFilters[0].Add(new [] { "ns:tagname1=tag1value1", "ns:tagname1=tag1value2"} );
+            matchFilters.Add(new List<IEnumerable<string>>());
+            matchFilters[1].Add(new [] { "ns:tagname=tagvalue3", "ns:tagname=tagvalue4" } );
+            matchFilters[1].Add(new [] { "ns:tagname1=tag1value3", "ns:tagname1=tag1value4"} );
+
+            var matchFilter1 = matchFilters[0];
+            var matchFilter2 = matchFilters[1];
+
+            var filters = new List<(IEnumerable<string> matchFilters1, IEnumerable<string> matchFilters2)>
+            {
+                (matchFilters[0][0], matchFilters[0][1]),
+                (matchFilters[1][0], matchFilters[1][1]),
+            };
+
+            var queryFilters = filters.SelectMany(f => new[]
+            {
+                new[]
+                {
+                    f.matchFilters1,
+                    f.matchFilters2
+                }
+            });
+            
             List<LinqTestInput> inputs = new List<LinqTestInput>
             {
                 // Equals
@@ -906,7 +934,56 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests.LinqProviderTests
                 // get_item
                 new LinqTestInput("get_item", b => getQuery(b).Select(doc => doc.EnumerableField[0])),
                 // TagsMatch
-                new LinqTestInput("TagsMatch", b => getQuery(b).Where(doc => CosmosTags.Match(doc.TagsField, new [] { "ns:name=1" }, TagsQueryOptions.Default)))
+                new LinqTestInput("TagsMatch", b => getQuery(b).Where(doc => CosmosTags.Match(doc.TagsField, new [] { "ns:name=1" }, TagsQueryOptions.Default))),
+                // TagsMatchAnySingleArray
+                new LinqTestInput("TagsMatchAnySingleArray", b => getQuery(b).Where(doc => CosmosTags.MatchAny(
+                    new MatchObjectList(
+                        new []
+                            {
+                                new MatchObject{DataTags = doc.TagsField, QueryTags = matchFilter1[0], QueryOptions = TagsQueryOptions.Basic, UdfName = "UdfName1"},
+                                new MatchObject{DataTags = doc.TagsField1, QueryTags = matchFilter1[1], QueryOptions = TagsQueryOptions.Basic }
+                            }
+                        )))),
+                // TagsMatchAnyMultipleArray
+                new LinqTestInput("TagsMatchAnyMultipleArray", b => getQuery(b).Where(doc => CosmosTags.MatchAny(
+                    new MatchObjectList(
+                        new []
+                        {
+                            new MatchObject{DataTags = doc.TagsField, QueryTags = matchFilter1[0], QueryOptions = TagsQueryOptions.Basic, UdfName = "UdfName1"},
+                            new MatchObject{DataTags = doc.TagsField1, QueryTags = matchFilter1[1], QueryOptions = TagsQueryOptions.Basic }
+                        }),
+                        new MatchObjectList(
+                        new []
+                        {
+                            new MatchObject{DataTags = doc.TagsField, QueryTags = matchFilter2[0], QueryOptions = TagsQueryOptions.Basic, UdfName = "UdfName1"},
+                            new MatchObject{DataTags = doc.TagsField1, QueryTags = matchFilter2[1], QueryOptions = TagsQueryOptions.Basic }
+                        })
+                    ))),
+                // TagsMatchAnySingleLinq
+                new LinqTestInput("TagsMatchAnySingleLinq", b => getQuery(b).Where(doc => CosmosTags.MatchAny(
+                    matchFilters.Select(f =>
+                        new MatchObjectList
+                        (
+                            new []
+                            {
+                                new MatchObject{DataTags = doc.TagsField, QueryTags = f[0], QueryOptions = TagsQueryOptions.Basic, UdfName = "UdfName1"},
+                                new MatchObject{DataTags = doc.TagsField1, QueryTags = f[1], QueryOptions = TagsQueryOptions.Basic }
+                            }
+                        )
+                    )))),
+                // TagsMatchAnyMultipleLinq
+                new LinqTestInput("TagsMatchAnySingleLinqQuery", b => getQuery(b).Where(doc => CosmosTags.MatchAny(
+                    queryFilters.Select(f =>
+                        new MatchObjectList
+                        (
+                            new []
+                            {
+                                new MatchObject{DataTags = doc.TagsField, QueryTags = f[0], QueryOptions = TagsQueryOptions.Basic, UdfName = "UdfName1"},
+                                new MatchObject{DataTags = doc.TagsField1, QueryTags = f[1], QueryOptions = TagsQueryOptions.Basic }
+                            }
+                        )
+                    ))))
+
             };
             this.ExecuteTestSuite(inputs);
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OfflineEngine/AggregateProjectionDector.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OfflineEngine/AggregateProjectionDector.cs
@@ -183,6 +183,16 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
                     return false;
                 }
 
+                public override bool Visit(SqlTagsMatchExpressionList scalarExpression)
+                {
+                    return false;
+                }
+
+                public override bool Visit(SqlTagsMatchExpressionLists scalarExpression)
+                {
+                    return false;
+                }
+
                 public override bool Visit(SqlUnaryScalarExpression sqlUnaryScalarExpression)
                 {
                     return sqlUnaryScalarExpression.Expression.Accept(this);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OfflineEngine/AggregateProjectionTransformer.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OfflineEngine/AggregateProjectionTransformer.cs
@@ -344,6 +344,16 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
                     return scalarExpression;
                 }
 
+                public override SqlScalarExpression Visit(SqlTagsMatchExpressionList scalarExpression)
+                {
+                    return scalarExpression;
+                }
+
+                public override SqlScalarExpression Visit(SqlTagsMatchExpressionLists scalarExpression)
+                {
+                    return scalarExpression;
+                }
+
                 public override SqlScalarExpression Visit(SqlUnaryScalarExpression sqlUnaryScalarExpression)
                 {
                     return SqlUnaryScalarExpression.Create(

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OfflineEngine/ScalarExpressionEvaluator.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OfflineEngine/ScalarExpressionEvaluator.cs
@@ -390,6 +390,8 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
         }
 
         public override CosmosElement Visit(SqlTagsMatchExpression sqlObject, CosmosElement input) => CosmosUndefined.Create();
+        public override CosmosElement Visit(SqlTagsMatchExpressionList sqlObject, CosmosElement input) => CosmosUndefined.Create();
+        public override CosmosElement Visit(SqlTagsMatchExpressionLists sqlObject, CosmosElement input) => CosmosUndefined.Create();
 
         public override CosmosElement Visit(SqlUnaryScalarExpression scalarExpression, CosmosElement document)
         {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OfflineEngine/SqlInterpreter.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OfflineEngine/SqlInterpreter.cs
@@ -869,6 +869,16 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
                     return false;
                 }
 
+                public override bool Visit(SqlTagsMatchExpressionList scalarExpression)
+                {
+                    return false;
+                }
+
+                public override bool Visit(SqlTagsMatchExpressionLists scalarExpression)
+                {
+                    return false;
+                }
+
                 public override bool Visit(SqlUnaryScalarExpression scalarExpression)
                 {
                     if (this.MatchesGroupByExpression(scalarExpression))


### PR DESCRIPTION
# Add MatchAny to Tags

## Description
Add the ability to use MatchAny as a LINQ extension method.
Uses a similar approach to Match with the ability to combine ANDs/ORs for Tags

eg.
`query.Where(doc => MatchAny(new [] {new MatchObjectList(new [] {new MatchObject() {DataTags = doc.TagsField, QueryTags = DisplayClass.matchFilter1.get_Item(0), QueryOptions = Basic, UdfName = "UdfName1"}, new MatchObject() {DataTags = doc.TagsField1, QueryTags = DisplayClass.matchFilter1.get_Item(1), QueryOptions = Basic}}), new MatchObjectList(new [] {new MatchObject() {DataTags = doc.TagsField, QueryTags = DisplayClass.matchFilter2.get_Item(0), QueryOptions = Basic, UdfName = "UdfName1"}, new MatchObject() {DataTags = doc.TagsField1, QueryTags = DisplayClass.matchFilter2.get_Item(1), QueryOptions = Basic}})}))`

will produce
`SELECT VALUE root 
FROM root 
WHERE ((((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue1") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue2")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value1") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value2")))))) OR (((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue3") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue4")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value3") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value4")))))))`

Add Tags MatchAny clause to support generating AND/OR expressions for Tag matching
- Add new MatchAny to the CosmosTags.cs that supports using a MatchObjectList
- Add the MatchAny to the ExpressionToSQL.cs and include LINQ handling of specific Select/Array
- Implement the AND/OR handling as part of the Visit() in the SqlObjectTextSerializer.cs
- Update the relevant classes to implement the new expressions
- Update the Unit Test generation using UpdateContracts.ps1
- Increment the NuGet package version to 3.32.1006-ca

Please include a summary of the change and which issue is fixed. Include samples if adding new API, and include relevant motivation and context. List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

- [] New feature (non-breaking change which adds functionality)

## Closing issues

To automatically close an issue: closes #IssueNumber