### PR TITLE
Add MatchAny to Tags

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Linq/CosmosTags.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/CosmosTags.cs
@@ -43,6 +43,11 @@ namespace Microsoft.Azure.Cosmos.Linq
     public static class CosmosTags
     {
         /// <summary>
+        /// The default UdfNane "TagsMatch"
+        /// </summary>
+        public const string UdfNameDefault = "TagsMatch";
+    
+        /// <summary>
         /// Tag matching for LINQ
         /// </summary>
         /// <param name="dataTags">The data tags</param>
@@ -59,25 +64,25 @@ namespace Microsoft.Azure.Cosmos.Linq
         /// <param name="queryOptions">Tag query options for performance </param>
         /// <param name="udfName">The name of the tag matching UDF when TagsQueryOptions.DocumentRequiredTags is specified</param>
         /// <returns>throws Exception</returns>
-        public static bool Match(object dataTags, object queryTags, TagsQueryOptions queryOptions, string udfName = "TagsMatch") => throw new Exception("CosmosTags.Match is only for linq expressions");
+        public static bool Match(object dataTags, object queryTags, TagsQueryOptions queryOptions, string udfName = UdfNameDefault) => throw new Exception("CosmosTags.Match is only for linq expressions");
 
         /// <summary>
         /// Matches any of the Filters using OR.
-        /// Each Filter is evaluated using ANY
+        /// Each FilterList is evaluated using AND
         /// </summary>
         /// <param name="filters">List of MatchObjectList</param>
         /// <returns>True if any Filter matches</returns>
         /// <exception cref="Exception">Used in LINQ</exception>
-        public static bool MatchAny(IEnumerable<MatchObjectList> filters) => throw new Exception("CosmosTags.Match is only for linq expressions");
+        public static bool MatchAny(IEnumerable<MatchObjectList> filters) => throw new Exception("CosmosTags.MatchAny is only for linq expressions");
 
         /// <summary>
         /// Matches any of the Filters using OR.
-        /// Each Filter is evaluated using ANY
+        /// Each FilterList is evaluated using AND
         /// </summary>
         /// <param name="filters">List of MatchObjectList</param>
         /// <returns>True if any Filter matches</returns>
         /// <exception cref="Exception">Used in LINQ</exception>
-        public static bool MatchAny(params MatchObjectList[] filters) => throw new Exception("CosmosTags.Match is only for linq expressions");
+        public static bool MatchAny(params MatchObjectList[] filters) => throw new Exception("CosmosTags.MatchAny is only for linq expressions");
 
         /// <summary>
         /// Creates and SQL WHERE condition string from a tag match expression.
@@ -87,7 +92,7 @@ namespace Microsoft.Azure.Cosmos.Linq
         /// <param name="queryOptions"></param>
         /// <param name="udfName">The name of the tag matching UDF when TagsQueryOptions.DocumentRequiredTags is specified</param>
         /// <returns>The tag expression as an SQL condition</returns>
-        public static string Condition(string tagsProp, IEnumerable<string> tags, TagsQueryOptions queryOptions, string udfName = "TagsMatch")
+        public static string Condition(string tagsProp, IEnumerable<string> tags, TagsQueryOptions queryOptions, string udfName = UdfNameDefault)
         {
             const char nullOperator = '\0';
             const char requiredOperator = '*';
@@ -303,6 +308,60 @@ namespace Microsoft.Azure.Cosmos.Linq
     /// </summary>
     public class MatchObject
     {
+        /// <summary>
+        /// Creates a new MatchObject
+        /// </summary>
+        /// <param name="dataTags"></param>
+        /// <param name="queryTags"></param>
+        /// <param name="tagsQueryOptions"></param>
+        /// <returns>new MatchObject</returns>
+        public static MatchObject Create(object dataTags, IEnumerable<string> queryTags, TagsQueryOptions tagsQueryOptions)
+            => Create(dataTags, queryTags, tagsQueryOptions, CosmosTags.UdfNameDefault);
+
+        /// <summary>
+        /// Creates a new MatchObject
+        /// </summary>
+        /// <param name="dataTags"></param>
+        /// <param name="queryTags"></param>
+        /// <param name="tagsQueryOptions"></param>
+        /// <param name="udfName"></param>
+        /// <returns>new MatchObject</returns>
+        public static MatchObject Create(object dataTags, IEnumerable<string> queryTags, TagsQueryOptions tagsQueryOptions, string udfName = CosmosTags.UdfNameDefault)
+            => new (dataTags, queryTags, tagsQueryOptions, udfName);
+
+        /// <summary>
+        /// Creates a new MatchObject
+        /// </summary>
+        public MatchObject()
+        {
+        }
+
+        /// <summary>
+        /// Creates a new MatchObject
+        /// </summary>
+        /// <param name="dataTags"></param>
+        /// <param name="queryTags"></param>
+        /// <param name="tagsQueryOptions"></param>
+        public MatchObject(object dataTags, IEnumerable<string> queryTags, TagsQueryOptions tagsQueryOptions)
+            : this(dataTags, queryTags, tagsQueryOptions, CosmosTags.UdfNameDefault)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new MatchObject
+        /// </summary>
+        /// <param name="dataTags"></param>
+        /// <param name="queryTags"></param>
+        /// <param name="tagsQueryOptions"></param>
+        /// <param name="udfName"></param>
+        public MatchObject(object dataTags, IEnumerable<string> queryTags, TagsQueryOptions tagsQueryOptions, string udfName)
+        {
+            DataTags = dataTags;
+            QueryTags = queryTags;
+            QueryOptions = tagsQueryOptions;
+            UdfName = udfName;
+        }
+        
         /// <summary>
         /// The expression for the tags on the document
         /// </summary>

--- a/Microsoft.Azure.Cosmos/src/Linq/CosmosTags.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/CosmosTags.cs
@@ -5,6 +5,7 @@
 namespace Microsoft.Azure.Cosmos.Linq
 {
     using System;
+    using System.Collections;
     using System.Collections.Generic;
     using System.Linq;
     using System.Text;
@@ -35,7 +36,7 @@ namespace Microsoft.Azure.Cosmos.Linq
         /// </summary>
         Default = Basic | DocumentNotTags,
     }
-
+    
     /// <summary>
     /// Tag matching for LINQ
     /// </summary>
@@ -59,6 +60,24 @@ namespace Microsoft.Azure.Cosmos.Linq
         /// <param name="udfName">The name of the tag matching UDF when TagsQueryOptions.DocumentRequiredTags is specified</param>
         /// <returns>throws Exception</returns>
         public static bool Match(object dataTags, object queryTags, TagsQueryOptions queryOptions, string udfName = "TagsMatch") => throw new Exception("CosmosTags.Match is only for linq expressions");
+
+        /// <summary>
+        /// Matches any of the Filters using OR.
+        /// Each Filter is evaluated using ANY
+        /// </summary>
+        /// <param name="filters">List of MatchObjectList</param>
+        /// <returns>True if any Filter matches</returns>
+        /// <exception cref="Exception">Used in LINQ</exception>
+        public static bool MatchAny(IEnumerable<MatchObjectList> filters) => throw new Exception("CosmosTags.Match is only for linq expressions");
+
+        /// <summary>
+        /// Matches any of the Filters using OR.
+        /// Each Filter is evaluated using ANY
+        /// </summary>
+        /// <param name="filters">List of MatchObjectList</param>
+        /// <returns>True if any Filter matches</returns>
+        /// <exception cref="Exception">Used in LINQ</exception>
+        public static bool MatchAny(params MatchObjectList[] filters) => throw new Exception("CosmosTags.Match is only for linq expressions");
 
         /// <summary>
         /// Creates and SQL WHERE condition string from a tag match expression.
@@ -246,5 +265,59 @@ namespace Microsoft.Azure.Cosmos.Linq
 
             return sb.ToString();
         }
+    }
+    
+    /// <summary>
+    /// List of MatchObjects
+    /// </summary>
+    public class MatchObjectList : IEnumerable<MatchObject>
+    {
+        private readonly IEnumerable<MatchObject> matchObjects;
+
+        /// <summary>
+        /// Creates a new MatchObjectList
+        /// </summary>
+        public MatchObjectList() => matchObjects = Enumerable.Empty<MatchObject>();
+
+        /// <summary>
+        /// Creates a new MatchObjectList from an existing list
+        /// </summary>
+        /// <param name="matchObjects"></param>
+        public MatchObjectList(IEnumerable<MatchObject> matchObjects) => this.matchObjects = matchObjects;
+
+        /// <summary>
+        /// Get the Enumerator
+        /// </summary>
+        /// <returns>The Enumerator</returns>
+        public IEnumerator<MatchObject> GetEnumerator() => matchObjects.GetEnumerator();
+
+        /// <summary>
+        /// Get the Enumerator
+        /// </summary>
+        /// <returns>The Enumerator</returns>
+        IEnumerator IEnumerable.GetEnumerator() => matchObjects.GetEnumerator();
+    }
+    
+    /// <summary>
+    /// Used for TagMatchAny
+    /// </summary>
+    public class MatchObject
+    {
+        /// <summary>
+        /// The expression for the tags on the document
+        /// </summary>
+        public object DataTags { get; set; }
+        /// <summary>
+        /// The list of tags used to filter as string[]
+        /// </summary>
+        public IEnumerable<string> QueryTags { get; set; }
+        /// <summary>
+        /// The TagsQueryOptions 
+        /// </summary>
+        public TagsQueryOptions QueryOptions { get; set; }
+        /// <summary>
+        /// Optionally the name of the UdfName to use
+        /// </summary>
+        public string UdfName { get; set; }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
+++ b/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
@@ -41,7 +41,7 @@
 		<RootNamespace>Microsoft.Azure.Cosmos</RootNamespace>
 		<NoWarn>NU5125</NoWarn>
 		<Optimize Condition="'$(Configuration)'=='Release'">true</Optimize>
-		<PackageVersion>3.39.1000-ca</PackageVersion>
+		<PackageVersion>3.39.1001-ca</PackageVersion>
 		<LangVersion>$(LangVersion)</LangVersion>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
 	</PropertyGroup>

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CosmosQueryExecutionContextFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CosmosQueryExecutionContextFactory.cs
@@ -1091,6 +1091,16 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
                         return false;
                     }
 
+                    public override bool Visit(SqlTagsMatchExpressionList scalarExpression)
+                    {
+                        return false;
+                    }
+
+                    public override bool Visit(SqlTagsMatchExpressionLists scalarExpression)
+                    {
+                        return false;
+                    }
+
                     public override bool Visit(SqlUnaryScalarExpression sqlUnaryScalarExpression)
                     {
                         return sqlUnaryScalarExpression.Expression.Accept(this);

--- a/Microsoft.Azure.Cosmos/src/SqlObjects/SqlTagsMatchExpressionList.cs
+++ b/Microsoft.Azure.Cosmos/src/SqlObjects/SqlTagsMatchExpressionList.cs
@@ -1,0 +1,35 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.SqlObjects
+{
+    using System.Collections.Generic;
+    using Microsoft.Azure.Cosmos.Linq;
+    using Microsoft.Azure.Cosmos.SqlObjects.Visitors;
+
+    internal class SqlTagsMatchExpressionList : SqlScalarExpression
+    {
+        private SqlTagsMatchExpressionList(IEnumerable<SqlTagsMatchExpression> matches)
+        {
+            this.MatchesList = matches ?? new List<SqlTagsMatchExpression>();
+        }
+
+        public IEnumerable<SqlTagsMatchExpression> MatchesList { get; }
+
+        public static SqlTagsMatchExpressionList Create(IEnumerable<SqlTagsMatchExpression> matches)
+            => new SqlTagsMatchExpressionList(matches);
+
+        public override void Accept(SqlObjectVisitor visitor) => visitor.Visit(this);
+
+        public override TResult Accept<TResult>(SqlObjectVisitor<TResult> visitor) => visitor.Visit(this);
+
+        public override TResult Accept<T, TResult>(SqlObjectVisitor<T, TResult> visitor, T input) => visitor.Visit(this, input);
+
+        public override void Accept(SqlScalarExpressionVisitor visitor) => visitor.Visit(this);
+
+        public override TResult Accept<TResult>(SqlScalarExpressionVisitor<TResult> visitor) => visitor.Visit(this);
+
+        public override TResult Accept<T, TResult>(SqlScalarExpressionVisitor<T, TResult> visitor, T input) => visitor.Visit(this, input);
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/SqlObjects/SqlTagsMatchExpressionLists.cs
+++ b/Microsoft.Azure.Cosmos/src/SqlObjects/SqlTagsMatchExpressionLists.cs
@@ -1,0 +1,35 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.SqlObjects
+{
+    using System.Collections.Generic;
+    using Microsoft.Azure.Cosmos.Linq;
+    using Microsoft.Azure.Cosmos.SqlObjects.Visitors;
+
+    internal class SqlTagsMatchExpressionLists : SqlScalarExpression
+    {
+        private SqlTagsMatchExpressionLists(IEnumerable<SqlTagsMatchExpressionList> matches)
+        {
+            this.MatchesList = matches ?? new List<SqlTagsMatchExpressionList>();
+        }
+
+        public IEnumerable<SqlTagsMatchExpressionList> MatchesList { get; }
+
+        public static SqlTagsMatchExpressionLists Create(IEnumerable<SqlTagsMatchExpressionList> matches)
+            => new SqlTagsMatchExpressionLists(matches);
+
+        public override void Accept(SqlObjectVisitor visitor) => visitor.Visit(this);
+
+        public override TResult Accept<TResult>(SqlObjectVisitor<TResult> visitor) => visitor.Visit(this);
+
+        public override TResult Accept<T, TResult>(SqlObjectVisitor<T, TResult> visitor, T input) => visitor.Visit(this, input);
+
+        public override void Accept(SqlScalarExpressionVisitor visitor) => visitor.Visit(this);
+
+        public override TResult Accept<TResult>(SqlScalarExpressionVisitor<TResult> visitor) => visitor.Visit(this);
+
+        public override TResult Accept<T, TResult>(SqlScalarExpressionVisitor<T, TResult> visitor, T input) => visitor.Visit(this, input);
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/SqlObjects/Visitors/SqlObjectEqualityVisitor.cs
+++ b/Microsoft.Azure.Cosmos/src/SqlObjects/Visitors/SqlObjectEqualityVisitor.cs
@@ -936,6 +936,52 @@ namespace Microsoft.Azure.Cosmos.SqlObjects.Visitors
             return true;
         }
 
+        public override bool Visit(SqlTagsMatchExpressionList first, SqlObject secondAsObject)
+        {
+            if (!(secondAsObject is SqlTagsMatchExpressionList second))
+            {
+                return false;
+            }
+
+            if (!Equals(first.MatchesList.Count(), second.MatchesList.Count()))
+            {
+                return false;
+            }
+
+            foreach (var firstMatch in first.MatchesList)
+            {
+                foreach (var secondMatch in second.MatchesList)
+                {
+                    if (!firstMatch.Equals(secondMatch))
+                        return false;
+                }                    
+            }
+
+            return true;
+        }
+
+        public override bool Visit(SqlTagsMatchExpressionLists first, SqlObject secondAsObject)
+        {
+            if (!(secondAsObject is SqlTagsMatchExpressionLists second))
+            {
+                return false;
+            }
+
+            if (!Equals(first.MatchesList.Count(), second.MatchesList.Count()))
+            {
+                return false;
+            }
+
+            foreach (var firstMatch in first.MatchesList)
+            {
+                var secondMatch = second.MatchesList.Any(x => Equals(firstMatch, x));
+                if (!secondMatch)
+                    return false;
+            }
+
+            return true;
+        }
+
         public override bool Visit(SqlTopSpec first, SqlObject secondAsObject)
         {
             if (!(secondAsObject is SqlTopSpec second))

--- a/Microsoft.Azure.Cosmos/src/SqlObjects/Visitors/SqlObjectHasher.cs
+++ b/Microsoft.Azure.Cosmos/src/SqlObjects/Visitors/SqlObjectHasher.cs
@@ -69,6 +69,7 @@ namespace Microsoft.Azure.Cosmos.SqlObjects.Visitors
         private const int SqlSubqueryCollectionHashCode = 1175697100;
         private const int SqlSubqueryScalarExpressionHashCode = -1327458193;
         private const int SqlTagsMatchExpressionHashCode = 957110162;
+        private const int SqlTagsMatchExpressionListHashCode = 957110163;
         private const int SqlTopSpecHashCode = -791376698;
         private const int SqlUnaryScalarExpressionHashCode = 723832597;
         private const int SqlUndefinedLiteralHashCode = 1290712518;
@@ -619,6 +620,22 @@ namespace Microsoft.Azure.Cosmos.SqlObjects.Visitors
             foreach (string tag in sqlTagsMatchExpression.Tags)
                 hashCode = CombineHashes(hashCode, tag.GetHashCode());
             hashCode = CombineHashes(hashCode, sqlTagsMatchExpression.QueryOptions.GetHashCode());
+            return hashCode;
+        }
+
+        public override int Visit(SqlTagsMatchExpressionList sqlTagsMatchExpressionList)
+        {
+            int hashCode = SqlTagsMatchExpressionListHashCode;
+            foreach (var match in sqlTagsMatchExpressionList.MatchesList)
+                hashCode = CombineHashes(hashCode, match.GetHashCode());
+            return hashCode;
+        }
+
+        public override int Visit(SqlTagsMatchExpressionLists sqlTagsMatchExpressionLists)
+        {
+            int hashCode = SqlTagsMatchExpressionListHashCode;
+            foreach (var match in sqlTagsMatchExpressionLists.MatchesList)
+                hashCode = CombineHashes(hashCode, match.GetHashCode());
             return hashCode;
         }
 

--- a/Microsoft.Azure.Cosmos/src/SqlObjects/Visitors/SqlObjectObfuscator.cs
+++ b/Microsoft.Azure.Cosmos/src/SqlObjects/Visitors/SqlObjectObfuscator.cs
@@ -408,6 +408,18 @@ namespace Microsoft.Azure.Cosmos.SqlObjects.Visitors
             return sqlObject;
         }
 
+        public override SqlObject Visit(SqlTagsMatchExpressionList sqlObject)
+        {
+            // No idea what this obfuscator does
+            return sqlObject;
+        }
+
+        public override SqlObject Visit(SqlTagsMatchExpressionLists sqlObject)
+        {
+            // No idea what this obfuscator does
+            return sqlObject;
+        }
+
         public override SqlObject Visit(SqlTopSpec sqlTopSpec)
         {
             return SqlTopSpec.Create(SqlNumberLiteral.Create(0));

--- a/Microsoft.Azure.Cosmos/src/SqlObjects/Visitors/SqlObjectTextSerializer.cs
+++ b/Microsoft.Azure.Cosmos/src/SqlObjects/Visitors/SqlObjectTextSerializer.cs
@@ -629,6 +629,48 @@ namespace Microsoft.Azure.Cosmos.SqlObjects.Visitors
             this.writer.Write(CosmosTags.Condition(tagsProp, tags, queryOptions, udfName));
         }
 
+        public override void Visit(SqlTagsMatchExpressionList sqlObject)
+        {
+            var matchesList = sqlObject.MatchesList;
+            if (matchesList == null || !matchesList.Any())
+            {
+                this.writer.Write("true");
+                return;
+            }
+            this.writer.Write("(");
+            for (int i = 0; i < matchesList.Count(); i++)
+            {
+                if (i > 0) this.writer.Write(" AND ");
+
+                var match = matchesList.ElementAt(i);
+                this.writer.Write("(");
+                Visit(match);
+                this.writer.Write(")");
+            }
+            this.writer.Write(")");
+        }
+
+        public override void Visit(SqlTagsMatchExpressionLists sqlObject)
+        {
+            var matchesList = sqlObject.MatchesList;
+            if (matchesList == null || !matchesList.Any())
+            {
+                this.writer.Write("true");
+                return;
+            }
+            this.writer.Write("(");
+            for (int i = 0; i < matchesList.Count(); i++)
+            {
+                if (i > 0) this.writer.Write(" OR ");
+                    
+                var matchList = matchesList.ElementAt(i);
+                this.writer.Write("(");
+                Visit(matchList);                
+                this.writer.Write(")");
+            }
+            this.writer.Write(")");
+        }
+
         public override void Visit(SqlTopSpec sqlTopSpec)
         {
             this.writer.Write("TOP ");

--- a/Microsoft.Azure.Cosmos/src/SqlObjects/Visitors/SqlObjectTextSerializer.cs
+++ b/Microsoft.Azure.Cosmos/src/SqlObjects/Visitors/SqlObjectTextSerializer.cs
@@ -631,18 +631,18 @@ namespace Microsoft.Azure.Cosmos.SqlObjects.Visitors
 
         public override void Visit(SqlTagsMatchExpressionList sqlObject)
         {
-            var matchesList = sqlObject.MatchesList;
+            var matchesList = sqlObject.MatchesList?.ToArray();
             if (matchesList == null || !matchesList.Any())
             {
                 this.writer.Write("true");
                 return;
             }
             this.writer.Write("(");
-            for (int i = 0; i < matchesList.Count(); i++)
+            for (int i = 0; i < matchesList.Length; i++)
             {
                 if (i > 0) this.writer.Write(" AND ");
 
-                var match = matchesList.ElementAt(i);
+                var match = matchesList[i];
                 this.writer.Write("(");
                 Visit(match);
                 this.writer.Write(")");
@@ -652,23 +652,31 @@ namespace Microsoft.Azure.Cosmos.SqlObjects.Visitors
 
         public override void Visit(SqlTagsMatchExpressionLists sqlObject)
         {
-            var matchesList = sqlObject.MatchesList;
+            var matchesList = sqlObject.MatchesList?.ToArray();
             if (matchesList == null || !matchesList.Any())
             {
                 this.writer.Write("true");
                 return;
             }
-            this.writer.Write("(");
-            for (int i = 0; i < matchesList.Count(); i++)
+
+            if (matchesList.Length == 1)
             {
-                if (i > 0) this.writer.Write(" OR ");
-                    
-                var matchList = matchesList.ElementAt(i);
+                Visit(matchesList[0]);                
+            }
+            else
+            {
                 this.writer.Write("(");
-                Visit(matchList);                
+                for (int i = 0; i < matchesList.Length; i++)
+                {
+                    if (i > 0) this.writer.Write(" OR ");
+                    
+                    var matchList = matchesList[i];
+                    this.writer.Write("(");
+                    Visit(matchList);                
+                    this.writer.Write(")");
+                }
                 this.writer.Write(")");
             }
-            this.writer.Write(")");
         }
 
         public override void Visit(SqlTopSpec sqlTopSpec)

--- a/Microsoft.Azure.Cosmos/src/SqlObjects/Visitors/SqlObjectVisitor.cs
+++ b/Microsoft.Azure.Cosmos/src/SqlObjects/Visitors/SqlObjectVisitor.cs
@@ -63,6 +63,8 @@ namespace Microsoft.Azure.Cosmos.SqlObjects.Visitors
         public abstract void Visit(SqlSubqueryCollection sqlObject);
         public abstract void Visit(SqlSubqueryScalarExpression sqlObject);
         public abstract void Visit(SqlTagsMatchExpression sqlObject);
+        public abstract void Visit(SqlTagsMatchExpressionList sqlObject);
+        public abstract void Visit(SqlTagsMatchExpressionLists sqlObject);
         public abstract void Visit(SqlTopSpec sqlObject);
         public abstract void Visit(SqlUnaryScalarExpression sqlObject);
         public abstract void Visit(SqlUndefinedLiteral sqlObject);

--- a/Microsoft.Azure.Cosmos/src/SqlObjects/Visitors/SqlObjectVisitor{TArg,TOutput}.cs
+++ b/Microsoft.Azure.Cosmos/src/SqlObjects/Visitors/SqlObjectVisitor{TArg,TOutput}.cs
@@ -63,6 +63,8 @@ namespace Microsoft.Azure.Cosmos.SqlObjects.Visitors
         public abstract TOutput Visit(SqlSubqueryCollection sqlObject, TArg input);
         public abstract TOutput Visit(SqlSubqueryScalarExpression sqlObject, TArg input);
         public abstract TOutput Visit(SqlTagsMatchExpression sqlObject, TArg input);
+        public abstract TOutput Visit(SqlTagsMatchExpressionList sqlObject, TArg input);
+        public abstract TOutput Visit(SqlTagsMatchExpressionLists sqlObject, TArg input);
         public abstract TOutput Visit(SqlTopSpec sqlObject, TArg input);
         public abstract TOutput Visit(SqlUnaryScalarExpression sqlObject, TArg input);
         public abstract TOutput Visit(SqlUndefinedLiteral sqlObject, TArg input);

--- a/Microsoft.Azure.Cosmos/src/SqlObjects/Visitors/SqlObjectVisitor{TResult}.cs
+++ b/Microsoft.Azure.Cosmos/src/SqlObjects/Visitors/SqlObjectVisitor{TResult}.cs
@@ -63,6 +63,8 @@ namespace Microsoft.Azure.Cosmos.SqlObjects.Visitors
         public abstract TResult Visit(SqlSubqueryCollection sqlObject);
         public abstract TResult Visit(SqlSubqueryScalarExpression sqlObject);
         public abstract TResult Visit(SqlTagsMatchExpression sqlObject);
+        public abstract TResult Visit(SqlTagsMatchExpressionList sqlObject);
+        public abstract TResult Visit(SqlTagsMatchExpressionLists sqlObject);
         public abstract TResult Visit(SqlTopSpec sqlObject);
         public abstract TResult Visit(SqlUnaryScalarExpression sqlObject);
         public abstract TResult Visit(SqlUndefinedLiteral sqlObject);

--- a/Microsoft.Azure.Cosmos/src/SqlObjects/Visitors/SqlScalarExpressionVisitor.cs
+++ b/Microsoft.Azure.Cosmos/src/SqlObjects/Visitors/SqlScalarExpressionVisitor.cs
@@ -32,6 +32,8 @@ namespace Microsoft.Azure.Cosmos.SqlObjects.Visitors
         public abstract void Visit(SqlPropertyRefScalarExpression scalarExpression);
         public abstract void Visit(SqlSubqueryScalarExpression scalarExpression);
         public abstract void Visit(SqlTagsMatchExpression scalarExpression);
+        public abstract void Visit(SqlTagsMatchExpressionList scalarExpression);
+        public abstract void Visit(SqlTagsMatchExpressionLists scalarExpression);
         public abstract void Visit(SqlUnaryScalarExpression scalarExpression);
     }
 }

--- a/Microsoft.Azure.Cosmos/src/SqlObjects/Visitors/SqlScalarExpressionVisitor{TArg,TOutput}.cs
+++ b/Microsoft.Azure.Cosmos/src/SqlObjects/Visitors/SqlScalarExpressionVisitor{TArg,TOutput}.cs
@@ -33,6 +33,8 @@ namespace Microsoft.Azure.Cosmos.SqlObjects.Visitors
         public abstract TOutput Visit(SqlPropertyRefScalarExpression scalarExpression, TArg input);
         public abstract TOutput Visit(SqlSubqueryScalarExpression scalarExpression, TArg input);
         public abstract TOutput Visit(SqlTagsMatchExpression sqlObject, TArg input);
+        public abstract TOutput Visit(SqlTagsMatchExpressionList sqlObject, TArg input);
+        public abstract TOutput Visit(SqlTagsMatchExpressionLists sqlObject, TArg input);
         public abstract TOutput Visit(SqlUnaryScalarExpression scalarExpression, TArg input);
     }
 }

--- a/Microsoft.Azure.Cosmos/src/SqlObjects/Visitors/SqlScalarExpressionVisitor{TResult}.cs
+++ b/Microsoft.Azure.Cosmos/src/SqlObjects/Visitors/SqlScalarExpressionVisitor{TResult}.cs
@@ -33,6 +33,8 @@ namespace Microsoft.Azure.Cosmos.SqlObjects.Visitors
         public abstract TResult Visit(SqlPropertyRefScalarExpression scalarExpression);
         public abstract TResult Visit(SqlSubqueryScalarExpression scalarExpression);
         public abstract TResult Visit(SqlTagsMatchExpression scalarExpression);
+        public abstract TResult Visit(SqlTagsMatchExpressionList scalarExpression);
+        public abstract TResult Visit(SqlTagsMatchExpressionLists scalarExpression);
         public abstract TResult Visit(SqlUnaryScalarExpression scalarExpression);
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.QueryAsync.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.QueryAsync.xml
@@ -3753,7 +3753,7 @@
     <ATTRIBUTE key="db.cosmosdb.item_count">Some Value</ATTRIBUTE>
     <ATTRIBUTE key="db.cosmosdb.activity_id">Some Value</ATTRIBUTE>
     <ATTRIBUTE key="db.cosmosdb.correlated_activity_id">Some Value</ATTRIBUTE>
-    <ATTRIBUTE key="db.cosmosdb.regions_contacted">South Central US</ATTRIBUTE>
+    <ATTRIBUTE key="db.cosmosdb.regions_contacted">South Central US,South Central US</ATTRIBUTE>
   </ACTIVITY>
   <EVENT name="LatencyOverThreshold" />
   <EVENT name="LatencyOverThreshold" />

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqTranslationBaselineTests.TestSpecialMethods.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqTranslationBaselineTests.TestSpecialMethods.xml
@@ -54,4 +54,69 @@ SELECT VALUE root["EnumerableField"][0]
 FROM root]]></SqlQuery>
     </Output>
   </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[TagsMatch]]></Description>
+      <Expression><![CDATA[query.Where(doc => Match(doc.TagsField, new [] {"ns:name=1"}, Default))]]></Expression>
+    </Input>
+    <Output>
+      <SqlQuery><![CDATA[
+SELECT VALUE root 
+FROM root 
+WHERE ((NOT(IS_DEFINED(root["TagsField"]["tags"]["!ns:name"])) OR NOT(ARRAY_CONTAINS(root["TagsField"]["tag"], "!ns:name=")) AND NOT(ARRAY_CONTAINS(root["TagsField"]["tag"], "!ns:name=1"))) AND (NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:name"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:name=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:name=1")))]]></SqlQuery>
+      <ErrorMessage><![CDATA[CosmosTags.Match is only for linq expressions]]></ErrorMessage>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[TagsMatchAnySingleArray]]></Description>
+      <Expression><![CDATA[query.Where(doc => MatchAny(new [] {new MatchObjectList(new [] {new MatchObject() {DataTags = doc.TagsField, QueryTags = DisplayClass.matchFilter1.get_Item(0), QueryOptions = Basic, UdfName = "UdfName1"}, new MatchObject() {DataTags = doc.TagsField1, QueryTags = DisplayClass.matchFilter1.get_Item(1), QueryOptions = Basic}})}))]]></Expression>
+    </Input>
+    <Output>
+      <SqlQuery><![CDATA[
+SELECT VALUE root 
+FROM root 
+WHERE ((((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue1") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue2")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value1") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value2")))))))]]></SqlQuery>
+      <ErrorMessage><![CDATA[CosmosTags.Match is only for linq expressions]]></ErrorMessage>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[TagsMatchAnyMultipleArray]]></Description>
+      <Expression><![CDATA[query.Where(doc => MatchAny(new [] {new MatchObjectList(new [] {new MatchObject() {DataTags = doc.TagsField, QueryTags = DisplayClass.matchFilter1.get_Item(0), QueryOptions = Basic, UdfName = "UdfName1"}, new MatchObject() {DataTags = doc.TagsField1, QueryTags = DisplayClass.matchFilter1.get_Item(1), QueryOptions = Basic}}), new MatchObjectList(new [] {new MatchObject() {DataTags = doc.TagsField, QueryTags = DisplayClass.matchFilter2.get_Item(0), QueryOptions = Basic, UdfName = "UdfName1"}, new MatchObject() {DataTags = doc.TagsField1, QueryTags = DisplayClass.matchFilter2.get_Item(1), QueryOptions = Basic}})}))]]></Expression>
+    </Input>
+    <Output>
+      <SqlQuery><![CDATA[
+SELECT VALUE root 
+FROM root 
+WHERE ((((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue1") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue2")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value1") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value2")))))) OR (((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue3") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue4")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value3") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value4")))))))]]></SqlQuery>
+      <ErrorMessage><![CDATA[CosmosTags.Match is only for linq expressions]]></ErrorMessage>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[TagsMatchAnySingleLinq]]></Description>
+      <Expression><![CDATA[query.Where(doc => MatchAny(DisplayClass.matchFilters.Select(f => new MatchObjectList(new [] {new MatchObject() {DataTags = doc.TagsField, QueryTags = f.get_Item(0), QueryOptions = Basic, UdfName = "UdfName1"}, new MatchObject() {DataTags = doc.TagsField1, QueryTags = f.get_Item(1), QueryOptions = Basic}}))))]]></Expression>
+    </Input>
+    <Output>
+      <SqlQuery><![CDATA[
+SELECT VALUE root 
+FROM root 
+WHERE ((((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue1") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue2")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value1") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value2")))))) OR (((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue3") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue4")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value3") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value4")))))))]]></SqlQuery>
+      <ErrorMessage><![CDATA[CosmosTags.Match is only for linq expressions]]></ErrorMessage>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[TagsMatchAnySingleLinqQuery]]></Description>
+      <Expression><![CDATA[query.Where(doc => MatchAny(DisplayClass.queryFilters.Select(f => new MatchObjectList(new [] {new MatchObject() {DataTags = doc.TagsField, QueryTags = f[0], QueryOptions = Basic, UdfName = "UdfName1"}, new MatchObject() {DataTags = doc.TagsField1, QueryTags = f[1], QueryOptions = Basic}}))))]]></Expression>
+    </Input>
+    <Output>
+      <SqlQuery><![CDATA[
+SELECT VALUE root 
+FROM root 
+WHERE ((((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue1") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue2")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value1") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value2")))))) OR (((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue3") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue4")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value3") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value4")))))))]]></SqlQuery>
+      <ErrorMessage><![CDATA[CosmosTags.Match is only for linq expressions]]></ErrorMessage>
+    </Output>
+  </Result>
 </Results>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqTranslationBaselineTests.TestSpecialMethods.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqTranslationBaselineTests.TestSpecialMethods.xml
@@ -77,7 +77,7 @@ WHERE ((NOT(IS_DEFINED(root["TagsField"]["tags"]["!ns:name"])) OR NOT(ARRAY_CONT
 SELECT VALUE root 
 FROM root 
 WHERE ((((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue1") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue2")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value1") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value2")))))))]]></SqlQuery>
-      <ErrorMessage><![CDATA[CosmosTags.Match is only for linq expressions]]></ErrorMessage>
+      <ErrorMessage><![CDATA[CosmosTags.MatchAny is only for linq expressions]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -90,7 +90,7 @@ WHERE ((((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CO
 SELECT VALUE root 
 FROM root 
 WHERE ((((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue1") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue2")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value1") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value2")))))) OR (((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue3") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue4")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value3") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value4")))))))]]></SqlQuery>
-      <ErrorMessage><![CDATA[CosmosTags.Match is only for linq expressions]]></ErrorMessage>
+      <ErrorMessage><![CDATA[CosmosTags.MatchAny is only for linq expressions]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -103,7 +103,7 @@ WHERE ((((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CO
 SELECT VALUE root 
 FROM root 
 WHERE ((((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue1") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue2")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value1") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value2")))))) OR (((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue3") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue4")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value3") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value4")))))))]]></SqlQuery>
-      <ErrorMessage><![CDATA[CosmosTags.Match is only for linq expressions]]></ErrorMessage>
+      <ErrorMessage><![CDATA[CosmosTags.MatchAny is only for linq expressions]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -116,7 +116,98 @@ WHERE ((((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CO
 SELECT VALUE root 
 FROM root 
 WHERE ((((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue1") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue2")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value1") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value2")))))) OR (((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue3") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue4")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value3") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value4")))))))]]></SqlQuery>
-      <ErrorMessage><![CDATA[CosmosTags.Match is only for linq expressions]]></ErrorMessage>
+      <ErrorMessage><![CDATA[CosmosTags.MatchAny is only for linq expressions]]></ErrorMessage>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[TagsMatchAnySingleLinqQuery]]></Description>
+      <Expression><![CDATA[query.Where(doc => MatchAny(DisplayClass.filters.Select(f => new MatchObjectList(new [] {new MatchObject() {DataTags = doc.TagsField, QueryTags = f.Item1, QueryOptions = Basic, UdfName = "UdfName1"}, new MatchObject() {DataTags = doc.TagsField1, QueryTags = f.Item2, QueryOptions = Basic}}))))]]></Expression>
+    </Input>
+    <Output>
+      <SqlQuery><![CDATA[
+SELECT VALUE root 
+FROM root 
+WHERE ((((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue1") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue2")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value1") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value2")))))) OR (((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue3") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue4")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value3") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value4")))))))]]></SqlQuery>
+      <ErrorMessage><![CDATA[CosmosTags.MatchAny is only for linq expressions]]></ErrorMessage>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[TagsMatchAnySingleArrayConstructor]]></Description>
+      <Expression><![CDATA[query.Where(doc => MatchAny(new [] {new MatchObjectList(new [] {new MatchObject(doc.TagsField, DisplayClass.matchFilter1.get_Item(0), Basic, "UdfName1"), Create(doc.TagsField1, DisplayClass.matchFilter1.get_Item(1), Basic)})}))]]></Expression>
+    </Input>
+    <Output>
+      <SqlQuery><![CDATA[
+SELECT VALUE root 
+FROM root 
+WHERE ((((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue1") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue2")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value1") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value2")))))))]]></SqlQuery>
+      <ErrorMessage><![CDATA[CosmosTags.MatchAny is only for linq expressions]]></ErrorMessage>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[TagsMatchAnyMultipleArrayConstructor]]></Description>
+      <Expression><![CDATA[query.Where(doc => MatchAny(new [] {new MatchObjectList(new [] {new MatchObject(doc.TagsField, DisplayClass.matchFilter1.get_Item(0), Basic, "UdfName1"), Create(doc.TagsField1, DisplayClass.matchFilter1.get_Item(1), Basic)}), new MatchObjectList(new [] {new MatchObject(doc.TagsField, DisplayClass.matchFilter2.get_Item(0), Basic, "UdfName1"), Create(doc.TagsField1, DisplayClass.matchFilter2.get_Item(1), Basic)})}))]]></Expression>
+    </Input>
+    <Output>
+      <SqlQuery><![CDATA[
+SELECT VALUE root 
+FROM root 
+WHERE ((((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue1") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue2")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value1") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value2")))))) OR (((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue3") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue4")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value3") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value4")))))))]]></SqlQuery>
+      <ErrorMessage><![CDATA[CosmosTags.MatchAny is only for linq expressions]]></ErrorMessage>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[TagsMatchAnySingleLinqConstructor]]></Description>
+      <Expression><![CDATA[query.Where(doc => MatchAny(DisplayClass.matchFilters.Select(f => new MatchObjectList(new [] {new MatchObject(doc.TagsField, f.get_Item(0), Basic, "UdfName1"), Create(doc.TagsField1, f.get_Item(1), Basic)}))))]]></Expression>
+    </Input>
+    <Output>
+      <SqlQuery><![CDATA[
+SELECT VALUE root 
+FROM root 
+WHERE ((((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue1") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue2")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value1") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value2")))))) OR (((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue3") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue4")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value3") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value4")))))))]]></SqlQuery>
+      <ErrorMessage><![CDATA[CosmosTags.MatchAny is only for linq expressions]]></ErrorMessage>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[TagsMatchAnySingleLinqQueryConstructor]]></Description>
+      <Expression><![CDATA[query.Where(doc => MatchAny(DisplayClass.queryFilters.Select(f => new MatchObjectList(new [] {new MatchObject(doc.TagsField, f[0], Basic, "UdfName1"), Create(doc.TagsField1, f[1], Basic)}))))]]></Expression>
+    </Input>
+    <Output>
+      <SqlQuery><![CDATA[
+SELECT VALUE root 
+FROM root 
+WHERE ((((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue1") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue2")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value1") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value2")))))) OR (((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue3") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue4")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value3") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value4")))))))]]></SqlQuery>
+      <ErrorMessage><![CDATA[CosmosTags.MatchAny is only for linq expressions]]></ErrorMessage>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[TagsMatchAnySingleLinqQuerySelectConstructor]]></Description>
+      <Expression><![CDATA[query.Where(doc => MatchAny(DisplayClass.queryFilters.Select(f => new MatchObjectList(new [] {new MatchObject(doc.TagsField, f[0], Basic, "UdfName1"), Create(doc.TagsField1, f[1], Basic)}))))]]></Expression>
+    </Input>
+    <Output>
+      <SqlQuery><![CDATA[
+SELECT VALUE root 
+FROM root 
+WHERE ((((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue1") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue2")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value1") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value2")))))) OR (((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue3") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue4")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value3") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value4")))))))]]></SqlQuery>
+      <ErrorMessage><![CDATA[CosmosTags.MatchAny is only for linq expressions]]></ErrorMessage>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[TagsMatchAnySingleLinqQuerySelectTupleConstructor]]></Description>
+      <Expression><![CDATA[query.Where(doc => MatchAny(DisplayClass.filters.Select(f => new MatchObjectList(new [] {new MatchObject(doc.TagsField, f.Item1, Basic, "UdfName1"), Create(doc.TagsField1, f.Item2, Basic)}))))]]></Expression>
+    </Input>
+    <Output>
+      <SqlQuery><![CDATA[
+SELECT VALUE root 
+FROM root 
+WHERE ((((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue1") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue2")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value1") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value2")))))) OR (((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue3") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue4")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value3") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value4")))))))]]></SqlQuery>
+      <ErrorMessage><![CDATA[CosmosTags.MatchAny is only for linq expressions]]></ErrorMessage>
     </Output>
   </Result>
 </Results>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqTranslationBaselineTests.TestSpecialMethods.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqTranslationBaselineTests.TestSpecialMethods.xml
@@ -76,7 +76,7 @@ WHERE ((NOT(IS_DEFINED(root["TagsField"]["tags"]["!ns:name"])) OR NOT(ARRAY_CONT
       <SqlQuery><![CDATA[
 SELECT VALUE root 
 FROM root 
-WHERE ((((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue1") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue2")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value1") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value2")))))))]]></SqlQuery>
+WHERE ((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue1") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue2")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value1") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value2")))))]]></SqlQuery>
       <ErrorMessage><![CDATA[CosmosTags.MatchAny is only for linq expressions]]></ErrorMessage>
     </Output>
   </Result>
@@ -141,7 +141,7 @@ WHERE ((((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CO
       <SqlQuery><![CDATA[
 SELECT VALUE root 
 FROM root 
-WHERE ((((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue1") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue2")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value1") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value2")))))))]]></SqlQuery>
+WHERE ((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue1") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue2")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value1") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value2")))))]]></SqlQuery>
       <ErrorMessage><![CDATA[CosmosTags.MatchAny is only for linq expressions]]></ErrorMessage>
     </Output>
   </Result>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Linq/LinqTranslationBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Linq/LinqTranslationBaselineTests.cs
@@ -155,6 +155,7 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests.LinqProviderTests
             public string Pk;
 
             public string[] TagsField;
+            public string[] TagsField1;
         }
 
         internal class SimpleObject
@@ -949,10 +950,37 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests.LinqProviderTests
                 obj.Id = Guid.NewGuid().ToString();
                 obj.Pk = "Test";
                 obj.TagsField = new string[0];
+                obj.TagsField1 = new string[0];
                 return obj;
             };
             Func<bool, IQueryable<DataObject>> getQuery = LinqTestsCommon.GenerateTestCosmosData(createDataObj, Records, testContainer);
 
+            var matchFilters = new List<List<IEnumerable<string>>>();
+            matchFilters.Add(new List<IEnumerable<string>>());
+            matchFilters[0].Add(new [] { "ns:tagname=tagvalue1", "ns:tagname=tagvalue2" } );
+            matchFilters[0].Add(new [] { "ns:tagname1=tag1value1", "ns:tagname1=tag1value2"} );
+            matchFilters.Add(new List<IEnumerable<string>>());
+            matchFilters[1].Add(new [] { "ns:tagname=tagvalue3", "ns:tagname=tagvalue4" } );
+            matchFilters[1].Add(new [] { "ns:tagname1=tag1value3", "ns:tagname1=tag1value4"} );
+
+            var matchFilter1 = matchFilters[0];
+            var matchFilter2 = matchFilters[1];
+
+            var filters = new List<(IEnumerable<string> matchFilters1, IEnumerable<string> matchFilters2)>
+            {
+                (matchFilters[0][0], matchFilters[0][1]),
+                (matchFilters[1][0], matchFilters[1][1]),
+            };
+
+            var queryFilters = filters.SelectMany(f => new[]
+            {
+                new[]
+                {
+                    f.matchFilters1,
+                    f.matchFilters2
+                }
+            });
+            
             List<LinqTestInput> inputs = new List<LinqTestInput>
             {
                 // Equals
@@ -966,7 +994,56 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests.LinqProviderTests
                 // get_item
                 new LinqTestInput("get_item", b => getQuery(b).Select(doc => doc.EnumerableField[0])),
                 // TagsMatch
-                new LinqTestInput("TagsMatch", b => getQuery(b).Where(doc => CosmosTags.Match(doc.TagsField, new [] { "ns:name=1" }, TagsQueryOptions.Default)))
+                new LinqTestInput("TagsMatch", b => getQuery(b).Where(doc => CosmosTags.Match(doc.TagsField, new [] { "ns:name=1" }, TagsQueryOptions.Default))),
+                // TagsMatchAnySingleArray
+                new LinqTestInput("TagsMatchAnySingleArray", b => getQuery(b).Where(doc => CosmosTags.MatchAny(
+                    new MatchObjectList(
+                        new []
+                            {
+                                new MatchObject{DataTags = doc.TagsField, QueryTags = matchFilter1[0], QueryOptions = TagsQueryOptions.Basic, UdfName = "UdfName1"},
+                                new MatchObject{DataTags = doc.TagsField1, QueryTags = matchFilter1[1], QueryOptions = TagsQueryOptions.Basic }
+                            }
+                        )))),
+                // TagsMatchAnyMultipleArray
+                new LinqTestInput("TagsMatchAnyMultipleArray", b => getQuery(b).Where(doc => CosmosTags.MatchAny(
+                    new MatchObjectList(
+                        new []
+                        {
+                            new MatchObject{DataTags = doc.TagsField, QueryTags = matchFilter1[0], QueryOptions = TagsQueryOptions.Basic, UdfName = "UdfName1"},
+                            new MatchObject{DataTags = doc.TagsField1, QueryTags = matchFilter1[1], QueryOptions = TagsQueryOptions.Basic }
+                        }),
+                        new MatchObjectList(
+                        new []
+                        {
+                            new MatchObject{DataTags = doc.TagsField, QueryTags = matchFilter2[0], QueryOptions = TagsQueryOptions.Basic, UdfName = "UdfName1"},
+                            new MatchObject{DataTags = doc.TagsField1, QueryTags = matchFilter2[1], QueryOptions = TagsQueryOptions.Basic }
+                        })
+                    ))),
+                // TagsMatchAnySingleLinq
+                new LinqTestInput("TagsMatchAnySingleLinq", b => getQuery(b).Where(doc => CosmosTags.MatchAny(
+                    matchFilters.Select(f =>
+                        new MatchObjectList
+                        (
+                            new []
+                            {
+                                new MatchObject{DataTags = doc.TagsField, QueryTags = f[0], QueryOptions = TagsQueryOptions.Basic, UdfName = "UdfName1"},
+                                new MatchObject{DataTags = doc.TagsField1, QueryTags = f[1], QueryOptions = TagsQueryOptions.Basic }
+                            }
+                        )
+                    )))),
+                // TagsMatchAnyMultipleLinq
+                new LinqTestInput("TagsMatchAnySingleLinqQuery", b => getQuery(b).Where(doc => CosmosTags.MatchAny(
+                    queryFilters.Select(f =>
+                        new MatchObjectList
+                        (
+                            new []
+                            {
+                                new MatchObject{DataTags = doc.TagsField, QueryTags = f[0], QueryOptions = TagsQueryOptions.Basic, UdfName = "UdfName1"},
+                                new MatchObject{DataTags = doc.TagsField1, QueryTags = f[1], QueryOptions = TagsQueryOptions.Basic }
+                            }
+                        )
+                    ))))
+
             };
             this.ExecuteTestSuite(inputs);
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Linq/LinqTranslationBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Linq/LinqTranslationBaselineTests.cs
@@ -1042,8 +1042,91 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests.LinqProviderTests
                                 new MatchObject{DataTags = doc.TagsField1, QueryTags = f[1], QueryOptions = TagsQueryOptions.Basic }
                             }
                         )
+                    )))),
+                // TagsMatchAnyMultipleLinqSelect
+                new LinqTestInput("TagsMatchAnySingleLinqQuery", b => getQuery(b).Where(doc => CosmosTags.MatchAny(
+                    filters.Select(f =>
+                        new MatchObjectList
+                        (
+                            new []
+                            {
+                                new MatchObject{DataTags = doc.TagsField, QueryTags = f.matchFilters1, QueryOptions = TagsQueryOptions.Basic, UdfName = "UdfName1"},
+                                new MatchObject{DataTags = doc.TagsField1, QueryTags = f.matchFilters2, QueryOptions = TagsQueryOptions.Basic }
+                            }
+                        )
+                    )))),
+                // TagsMatchAnySingleArrayConstructor
+                new LinqTestInput("TagsMatchAnySingleArrayConstructor", b => getQuery(b).Where(doc => CosmosTags.MatchAny(
+                    new MatchObjectList(
+                        new []
+                            {
+                                new MatchObject(doc.TagsField, matchFilter1[0], TagsQueryOptions.Basic, "UdfName1"),
+                                MatchObject.Create(doc.TagsField1, matchFilter1[1], TagsQueryOptions.Basic)
+                            }
+                        )))),
+                // TagsMatchAnyMultipleArrayConstructor
+                new LinqTestInput("TagsMatchAnyMultipleArrayConstructor", b => getQuery(b).Where(doc => CosmosTags.MatchAny(
+                    new MatchObjectList(
+                        new []
+                        {
+                            new MatchObject(doc.TagsField, matchFilter1[0], TagsQueryOptions.Basic, "UdfName1"),
+                            MatchObject.Create(doc.TagsField1, matchFilter1[1], TagsQueryOptions.Basic)
+                        }),
+                        new MatchObjectList(
+                        new []
+                        {
+                            new MatchObject(doc.TagsField, matchFilter2[0], TagsQueryOptions.Basic, "UdfName1"),
+                            MatchObject.Create(doc.TagsField1, matchFilter2[1], TagsQueryOptions.Basic)
+                        })
+                    ))),
+                // TagsMatchAnySingleLinqConstructor
+                new LinqTestInput("TagsMatchAnySingleLinqConstructor", b => getQuery(b).Where(doc => CosmosTags.MatchAny(
+                    matchFilters.Select(f =>
+                        new MatchObjectList
+                        (
+                            new []
+                            {
+                                new MatchObject(doc.TagsField, f[0], TagsQueryOptions.Basic, "UdfName1"),
+                                MatchObject.Create(doc.TagsField1, f[1], TagsQueryOptions.Basic)
+                            }
+                        )
+                    )))),
+                // TagsMatchAnyMultipleLinqConstructor
+                new LinqTestInput("TagsMatchAnySingleLinqQueryConstructor", b => getQuery(b).Where(doc => CosmosTags.MatchAny(
+                    queryFilters.Select(f =>
+                        new MatchObjectList
+                        (
+                            new []
+                            {
+                                new MatchObject(doc.TagsField, f[0], TagsQueryOptions.Basic, "UdfName1"),
+                                MatchObject.Create(doc.TagsField1, f[1], TagsQueryOptions.Basic)
+                            }
+                        )
+                   )))),
+                // TagsMatchAnyMultipleLinqSelectConstructor
+                new LinqTestInput("TagsMatchAnySingleLinqQuerySelectConstructor", b => getQuery(b).Where(doc => CosmosTags.MatchAny(
+                    queryFilters.Select(f =>
+                        new MatchObjectList
+                        (
+                            new []
+                            {
+                                new MatchObject(doc.TagsField, f[0], TagsQueryOptions.Basic, "UdfName1"),
+                                MatchObject.Create(doc.TagsField1, f[1], TagsQueryOptions.Basic)
+                            }
+                        )
+                    )))),
+                // TagsMatchAnyMultipleLinqSelectConstructor
+                new LinqTestInput("TagsMatchAnySingleLinqQuerySelectTupleConstructor", b => getQuery(b).Where(doc => CosmosTags.MatchAny(
+                    filters.Select(f =>
+                        new MatchObjectList
+                        (
+                            new []
+                            {
+                                new MatchObject(doc.TagsField, f.matchFilters1, TagsQueryOptions.Basic, "UdfName1"),
+                                MatchObject.Create(doc.TagsField1, f.matchFilters2, TagsQueryOptions.Basic)
+                            }
+                        )
                     ))))
-
             };
             this.ExecuteTestSuite(inputs);
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OfflineEngine/AggregateProjectionDector.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OfflineEngine/AggregateProjectionDector.cs
@@ -195,6 +195,16 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
                     return false;
                 }
 
+                public override bool Visit(SqlTagsMatchExpressionList scalarExpression)
+                {
+                    return false;
+                }
+
+                public override bool Visit(SqlTagsMatchExpressionLists scalarExpression)
+                {
+                    return false;
+                }
+
                 public override bool Visit(SqlUnaryScalarExpression sqlUnaryScalarExpression)
                 {
                     return sqlUnaryScalarExpression.Expression.Accept(this);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OfflineEngine/AggregateProjectionTransformer.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OfflineEngine/AggregateProjectionTransformer.cs
@@ -356,6 +356,16 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
                     return scalarExpression;
                 }
 
+                public override SqlScalarExpression Visit(SqlTagsMatchExpressionList scalarExpression)
+                {
+                    return scalarExpression;
+                }
+
+                public override SqlScalarExpression Visit(SqlTagsMatchExpressionLists scalarExpression)
+                {
+                    return scalarExpression;
+                }
+
                 public override SqlScalarExpression Visit(SqlUnaryScalarExpression sqlUnaryScalarExpression)
                 {
                     return SqlUnaryScalarExpression.Create(

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OfflineEngine/ScalarExpressionEvaluator.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OfflineEngine/ScalarExpressionEvaluator.cs
@@ -410,6 +410,8 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
         }
 
         public override CosmosElement Visit(SqlTagsMatchExpression sqlObject, CosmosElement input) => CosmosUndefined.Create();
+        public override CosmosElement Visit(SqlTagsMatchExpressionList sqlObject, CosmosElement input) => CosmosUndefined.Create();
+        public override CosmosElement Visit(SqlTagsMatchExpressionLists sqlObject, CosmosElement input) => CosmosUndefined.Create();
 
         public override CosmosElement Visit(SqlUnaryScalarExpression scalarExpression, CosmosElement document)
         {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OfflineEngine/SqlInterpreter.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OfflineEngine/SqlInterpreter.cs
@@ -879,6 +879,16 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
                     return false;
                 }
 
+                public override bool Visit(SqlTagsMatchExpressionList scalarExpression)
+                {
+                    return false;
+                }
+
+                public override bool Visit(SqlTagsMatchExpressionLists scalarExpression)
+                {
+                    return false;
+                }
+
                 public override bool Visit(SqlUnaryScalarExpression scalarExpression)
                 {
                     if (this.MatchesGroupByExpression(scalarExpression))


### PR DESCRIPTION
# Add MatchAny to Tags

## Description
Add the ability to use MatchAny as a LINQ extension method.
Uses a similar approach to Match with the ability to combine ANDs/ORs for Tags

eg.
`query.Where(doc => MatchAny(new [] {new MatchObjectList(new [] {new MatchObject() {DataTags = doc.TagsField, QueryTags = DisplayClass.matchFilter1.get_Item(0), QueryOptions = Basic, UdfName = "UdfName1"}, new MatchObject() {DataTags = doc.TagsField1, QueryTags = DisplayClass.matchFilter1.get_Item(1), QueryOptions = Basic}}), new MatchObjectList(new [] {new MatchObject() {DataTags = doc.TagsField, QueryTags = DisplayClass.matchFilter2.get_Item(0), QueryOptions = Basic, UdfName = "UdfName1"}, new MatchObject() {DataTags = doc.TagsField1, QueryTags = DisplayClass.matchFilter2.get_Item(1), QueryOptions = Basic}})}))`

will produce
`SELECT VALUE root 
FROM root 
WHERE ((((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue1") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue2")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value1") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value2")))))) OR (((((NOT(IS_DEFINED(root["TagsField"]["tags"]["ns:tagname"])) OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue3") OR ARRAY_CONTAINS(root["TagsField"]["tag"], "ns:tagname=tagvalue4")))) AND (((NOT(IS_DEFINED(root["TagsField1"]["tags"]["ns:tagname1"])) OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value3") OR ARRAY_CONTAINS(root["TagsField1"]["tag"], "ns:tagname1=tag1value4")))))))`

Add Tags MatchAny clause to support generating AND/OR expressions for Tag matching
- Add new MatchAny to the CosmosTags.cs that supports using a MatchObjectList
- Add the MatchAny to the ExpressionToSQL.cs and include LINQ handling of specific Select/Array
- Implement the AND/OR handling as part of the Visit() in the SqlObjectTextSerializer.cs
- Update the relevant classes to implement the new expressions
- Update the Unit Test generation using UpdateContracts.ps1
- Increment the NuGet package version to 3.39.1001-ca

## Type of change

Please delete options that are not relevant.

- [] New feature (non-breaking change which adds functionality)
To automatically close an issue: closes #IssueNumber